### PR TITLE
Daily summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ ehthumbs.db
 Thumbs.db
 
 .env
+.env.docker
 
 data/**/*
 tmp/**/*

--- a/Dockerfile_api
+++ b/Dockerfile_api
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.25-alpine AS builder
+WORKDIR /app
+
+RUN apk add --no-cache ca-certificates git
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY cmd ./cmd
+COPY internal ./internal
+
+RUN CGO_ENABLED=0 \
+	go build -trimpath -ldflags "-s -w" -o /out/api ./cmd/api
+
+FROM alpine:3.20
+WORKDIR /app
+
+RUN apk add --no-cache ca-certificates \
+	&& adduser -D -g '' appuser
+
+COPY --from=builder /out/api ./api
+
+USER appuser
+EXPOSE 8080
+ENTRYPOINT ["./api"]

--- a/Dockerfile_worker
+++ b/Dockerfile_worker
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.25-alpine AS builder
+WORKDIR /app
+
+RUN apk add --no-cache ca-certificates git
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY cmd ./cmd
+COPY internal ./internal
+
+RUN CGO_ENABLED=0 \
+	go build -trimpath -ldflags "-s -w" -o /out/worker ./cmd/worker
+
+FROM alpine:3.20
+WORKDIR /app
+
+RUN apk add --no-cache ca-certificates \
+	&& adduser -D -g '' appuser \
+	&& chown -R appuser:appuser /app
+
+COPY --from=builder /out/worker ./worker
+
+USER appuser
+ENTRYPOINT ["./worker"]

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ run-mcp: ## Run the MCP stdio server
 run-worker: ## Run the worker: go run
 	go run $(CMD_DIR)/worker/main.go
 
+run-worker-cli: ## Run the worker CLI: go run
+	go run $(CMD_DIR)/worker-cli/main.go $(RECEIPT_NUMBER)
+
 run-web: ## Run the web server: npm run serve
 	cd web && npm run dev
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ To start the background worker:
 make run-worker
 ```
 
+### Run the Dry Run
+
+To run the dry run:
+
+```bash
+RECEIPT_NUMBER=20260109900734 make run-worker-cli
+```
+
 ### Run Tests
 
 To execute the test suite:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ To verify the MCP server is running:
 npx @modelcontextprotocol/inspector ./bin/kosis-mcp
 ```
 
+### Run with docker compose
+
+```bash
+docker compose up
+```
+
 ## Database Migrations
 
 Ensure your `DATABASE_URL` environment variable is set before running migrations.

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -97,7 +97,7 @@ func main() {
 	// 중요: 로그는 반드시 Stderr로 출력해야 합니다. (Stdout은 통신용)
 	log.SetOutput(os.Stderr)
 
-	baseURL := strings.TrimRight(getEnv("KOSIS_BASE_URL", "http://localhost:8080/api/v1/mcp"), "/")
+	baseURL := strings.TrimRight(getEnv("KOSIS_BASE_URL", "http://localhost:8080/api/v1"), "/")
 	server := &MCPServer{
 		baseURL: baseURL,
 		client: &http.Client{
@@ -151,6 +151,20 @@ func main() {
 							"description": "Filter reports with receipt date < YYYY-MM-DD.",
 						},
 					},
+				},
+			},
+			{
+				Name:        "reports_summary_and_raw_by_receipt_number",
+				Description: "Get report summary and raw report by receipt number.",
+				InputSchema: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"receipt_number": map[string]interface{}{
+							"type":        "string",
+							"description": "Receipt number.",
+						},
+					},
+					"required": []string{"receipt_number"},
 				},
 			},
 		},
@@ -293,6 +307,16 @@ func (s *MCPServer) handleToolCall(req Request) *Response {
 			}
 		}
 		return s.reply(req, result)
+	case "reports_summary_and_raw_by_receipt_number":
+		result, rpcErr := s.callReportsSummaryAndRawByReceiptNumber(params.Arguments)
+		if rpcErr != nil {
+			return &Response{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Error:   rpcErr,
+			}
+		}
+		return s.reply(req, result)
 	default:
 		return s.error(req, -32601, fmt.Sprintf("tool not found: %s", params.Name), nil)
 	}
@@ -332,7 +356,7 @@ func (s *MCPServer) callReportsByCorpName(args map[string]interface{}) (*ToolCal
 		limit = 100
 	}
 
-	urlStr := fmt.Sprintf("%s/reports/by-corp-name?corp_name=%s&limit=%d", s.baseURL, urlEncode(corpName), limit)
+	urlStr := fmt.Sprintf("%s/mcp/reports/by-corp-name?corp_name=%s&limit=%d", s.baseURL, urlEncode(corpName), limit)
 
 	// 로그 추가 (디버깅용)
 	log.Printf("Calling upstream: %s", urlStr)
@@ -439,7 +463,59 @@ func (s *MCPServer) callReportsSummaryAllCompanies(args map[string]interface{}) 
 		query.Set("end_date", endDate)
 	}
 
-	urlStr := fmt.Sprintf("%s/reports?%s", s.apiBaseURL(), query.Encode())
+	urlStr := fmt.Sprintf("%s/reports?%s", s.baseURL, query.Encode())
+
+	log.Printf("Calling upstream: %s", urlStr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, &ResponseError{Code: -32000, Message: "failed to build request", Data: err.Error()}
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, &ResponseError{Code: -32000, Message: "request failed", Data: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, &ResponseError{Code: -32000, Message: "failed to read response", Data: err.Error()}
+	}
+
+	if resp.StatusCode >= 300 {
+		return nil, &ResponseError{Code: -32000, Message: fmt.Sprintf("upstream error: %s", resp.Status), Data: string(body)}
+	}
+
+	var raw json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		raw = json.RawMessage(fmt.Sprintf("%q", string(body)))
+	}
+
+	return &ToolCallResult{
+		Content: []ContentItem{
+			{
+				Type: "text",
+				Text: string(body),
+			},
+		},
+	}, nil
+}
+
+func (s *MCPServer) callReportsSummaryAndRawByReceiptNumber(args map[string]interface{}) (*ToolCallResult, *ResponseError) {
+	receiptNumber := ""
+	if rawReceiptNumber, ok := args["receipt_number"]; ok {
+		receiptNumberStr, ok := rawReceiptNumber.(string)
+		if !ok {
+			return nil, &ResponseError{Code: -32602, Message: "receipt_number must be a string"}
+		}
+		receiptNumber = strings.TrimSpace(receiptNumberStr)
+	}
+
+	urlStr := fmt.Sprintf("%s/reports/receipt/%s", s.baseURL, urlEncode(receiptNumber))
 
 	log.Printf("Calling upstream: %s", urlStr)
 
@@ -550,13 +626,6 @@ func getEnv(key, fallback string) string {
 		return v
 	}
 	return fallback
-}
-
-func (s *MCPServer) apiBaseURL() string {
-	if strings.HasSuffix(s.baseURL, "/mcp") {
-		return strings.TrimSuffix(s.baseURL, "/mcp")
-	}
-	return s.baseURL
 }
 
 func urlEncode(v string) string {

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -107,8 +107,8 @@ func main() {
 		out: bufio.NewWriter(os.Stdout),
 		tools: []Tool{
 			{
-				Name:        "reports_by_corp_name",
-				Description: "List recent reports matching a partial corp_name.",
+				Name:        "disclosures_reports_by_corp_name",
+				Description: "List recent reports or disclosures matching a partial corp_name.",
 				InputSchema: map[string]interface{}{
 					"type": "object",
 					"properties": map[string]interface{}{
@@ -124,6 +124,33 @@ func main() {
 						},
 					},
 					"required": []string{"corp_name"},
+				},
+			},
+			{
+				Name:        "reports_summary_all_companies",
+				Description: "Get report summaries across all companies.",
+				InputSchema: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"limit": map[string]interface{}{
+							"type":        "integer",
+							"minimum":     1,
+							"maximum":     100,
+							"description": "Number of reports to return (default 10).",
+						},
+						"corp_code": map[string]interface{}{
+							"type":        "string",
+							"description": "Optional corp code to filter results.",
+						},
+						"start_date": map[string]interface{}{
+							"type":        "string",
+							"description": "Filter reports with receipt date >= YYYY-MM-DD.",
+						},
+						"end_date": map[string]interface{}{
+							"type":        "string",
+							"description": "Filter reports with receipt date < YYYY-MM-DD.",
+						},
+					},
 				},
 			},
 		},
@@ -246,8 +273,18 @@ func (s *MCPServer) handleToolCall(req Request) *Response {
 	}
 
 	switch params.Name {
-	case "reports_by_corp_name":
+	case "disclosures_reports_by_corp_name":
 		result, rpcErr := s.callReportsByCorpName(params.Arguments)
+		if rpcErr != nil {
+			return &Response{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Error:   rpcErr,
+			}
+		}
+		return s.reply(req, result)
+	case "reports_summary_all_companies":
+		result, rpcErr := s.callReportsSummaryAllCompanies(params.Arguments)
 		if rpcErr != nil {
 			return &Response{
 				JSONRPC: "2.0",
@@ -340,6 +377,110 @@ func (s *MCPServer) callReportsByCorpName(args map[string]interface{}) (*ToolCal
 	}, nil
 }
 
+func (s *MCPServer) callReportsSummaryAllCompanies(args map[string]interface{}) (*ToolCallResult, *ResponseError) {
+	limit := 10
+	if rawLimit, ok := args["limit"]; ok {
+		switch v := rawLimit.(type) {
+		case float64:
+			limit = int(v)
+		case int:
+			limit = v
+		case json.Number:
+			if i, err := strconv.Atoi(string(v)); err == nil {
+				limit = i
+			}
+		default:
+			// limit 파싱 실패 시 기본값 사용
+		}
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	corpCode := ""
+	if rawCorpCode, ok := args["corp_code"]; ok {
+		corpCodeStr, ok := rawCorpCode.(string)
+		if !ok {
+			return nil, &ResponseError{Code: -32602, Message: "corp_code must be a string"}
+		}
+		corpCode = strings.TrimSpace(corpCodeStr)
+	}
+
+	startDate := ""
+	if rawStartDate, ok := args["start_date"]; ok {
+		startDateStr, ok := rawStartDate.(string)
+		if !ok {
+			return nil, &ResponseError{Code: -32602, Message: "start_date must be a string"}
+		}
+		startDate = strings.TrimSpace(startDateStr)
+	}
+
+	endDate := ""
+	if rawEndDate, ok := args["end_date"]; ok {
+		endDateStr, ok := rawEndDate.(string)
+		if !ok {
+			return nil, &ResponseError{Code: -32602, Message: "end_date must be a string"}
+		}
+		endDate = strings.TrimSpace(endDateStr)
+	}
+
+	query := url.Values{}
+	query.Set("limit", strconv.Itoa(limit))
+	if corpCode != "" {
+		query.Set("corp_code", corpCode)
+	}
+	if startDate != "" {
+		query.Set("start_date", startDate)
+	}
+	if endDate != "" {
+		query.Set("end_date", endDate)
+	}
+
+	urlStr := fmt.Sprintf("%s/reports?%s", s.apiBaseURL(), query.Encode())
+
+	log.Printf("Calling upstream: %s", urlStr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, &ResponseError{Code: -32000, Message: "failed to build request", Data: err.Error()}
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, &ResponseError{Code: -32000, Message: "request failed", Data: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, &ResponseError{Code: -32000, Message: "failed to read response", Data: err.Error()}
+	}
+
+	if resp.StatusCode >= 300 {
+		return nil, &ResponseError{Code: -32000, Message: fmt.Sprintf("upstream error: %s", resp.Status), Data: string(body)}
+	}
+
+	var raw json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		raw = json.RawMessage(fmt.Sprintf("%q", string(body)))
+	}
+
+	return &ToolCallResult{
+		Content: []ContentItem{
+			{
+				Type: "text",
+				Text: string(body),
+			},
+		},
+	}, nil
+}
+
 func (s *MCPServer) reply(req Request, result interface{}) *Response {
 	return &Response{
 		JSONRPC: "2.0",
@@ -409,6 +550,13 @@ func getEnv(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func (s *MCPServer) apiBaseURL() string {
+	if strings.HasSuffix(s.baseURL, "/mcp") {
+		return strings.TrimSuffix(s.baseURL, "/mcp")
+	}
+	return s.baseURL
 }
 
 func urlEncode(v string) string {

--- a/cmd/worker-cli/main.go
+++ b/cmd/worker-cli/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"kosis/internal/config"
+	"kosis/internal/pkg/dart"
+	"kosis/internal/pkg/openai"
+	"kosis/internal/tasks"
+	"log"
+	"os"
+)
+
+func main() {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		log.Fatalf("Failed to load configuration: %v", err)
+	}
+
+	if len(os.Args) != 2 {
+		log.Fatalf("Usage: %s <receipt_number>", os.Args[0])
+	}
+
+	dartClient := dart.New(cfg.DartAPIKey)
+	fileAnalyzer := openai.NewFileAnalyzer(cfg.OpenAIAPIKey)
+
+	receiptNumber := os.Args[1]
+	err = tasks.FetchReportDryRun(dartClient, fileAnalyzer, receiptNumber)
+	if err != nil {
+		log.Fatalf("Failed to fetch report: %v", err)
+	}
+
+	log.Println("Done")
+}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"kosis/internal/config"
 	"kosis/internal/db"
 	"kosis/internal/tasks"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/hibiken/asynq"
 )
@@ -31,6 +33,13 @@ func main() {
 
 	asynqClient := asynq.NewClient(redisOpt)
 	defer asynqClient.Close()
+
+	inspector := asynq.NewInspector(redisOpt)
+	defer func() {
+		if err := inspector.Close(); err != nil {
+			log.Printf("Failed to close inspector: %v", err)
+		}
+	}()
 
 	scheduler := asynq.NewScheduler(redisOpt, &asynq.SchedulerOpts{})
 	fetchReportsTask, err := tasks.NewFetchReportsTask(nil, nil)
@@ -85,7 +94,20 @@ func main() {
 	// asynqClient.Enqueue(fetchCompaniesTask)
 
 	// To submit manually
-	asynqClient.Enqueue(fetchReportsTask)
+	deleted, err := deleteTasksByType(inspector, "default", tasks.TypeTaskFetchReports)
+	if err != nil {
+		if !errors.Is(err, asynq.ErrQueueNotFound) {
+			log.Fatalf("Failed to clean fetch reports tasks: %v", err)
+		}
+	}
+
+	if deleted > 0 {
+		log.Printf("Deleted %d existing fetch reports tasks", deleted)
+	}
+
+	if _, err := asynqClient.Enqueue(fetchReportsTask, asynq.Queue("default"), asynq.Timeout(2*time.Hour)); err != nil {
+		log.Fatalf("Failed to enqueue fetch reports task: %v", err)
+	}
 
 	go func() {
 		log.Println("Starting Asynq scheduler...")
@@ -118,4 +140,53 @@ func main() {
 	log.Println("Asynq client closed.")
 
 	log.Println("Worker process shut down complete.")
+}
+
+func deleteTasksByType(inspector *asynq.Inspector, queue, taskType string) (int, error) {
+	listFns := []func(string, ...asynq.ListOption) ([]*asynq.TaskInfo, error){
+		inspector.ListPendingTasks,
+		inspector.ListScheduledTasks,
+		inspector.ListRetryTasks,
+		inspector.ListArchivedTasks,
+	}
+
+	total := 0
+	for _, listFn := range listFns {
+		tasks, err := listAllTasks(queue, listFn)
+		if err != nil {
+			return total, err
+		}
+		for _, task := range tasks {
+			if task.Type != taskType {
+				continue
+			}
+			if err := inspector.DeleteTask(queue, task.ID); err != nil {
+				return total, err
+			}
+			total++
+		}
+	}
+
+	return total, nil
+}
+
+func listAllTasks(queue string, listFn func(string, ...asynq.ListOption) ([]*asynq.TaskInfo, error)) ([]*asynq.TaskInfo, error) {
+	const pageSize = 100
+	var all []*asynq.TaskInfo
+	page := 1
+	for {
+		tasks, err := listFn(queue, asynq.Page(page), asynq.PageSize(pageSize))
+		if err != nil {
+			return nil, err
+		}
+		if len(tasks) == 0 {
+			break
+		}
+		all = append(all, tasks...)
+		if len(tasks) < pageSize {
+			break
+		}
+		page++
+	}
+	return all, nil
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,17 +9,43 @@ services:
     ports:
       - 5432:5432
     networks:
-      - local-network
+      - dart-local-network
   redis:
     image: redis/redis-stack-server:7.4.0-v8
     ports:
       - "6379:6379"
     volumes:
       - redis-data:/data
+    networks:
+      - dart-local-network
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile_worker
+    env_file:
+      - .env.docker
+    networks:
+      - dart-local-network
+    depends_on:
+      - db
+      - redis
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile_api
+    ports:
+      - 8080:8080
+    env_file:
+      - .env.docker
+    networks:
+      - dart-local-network
+    depends_on:
+      - db
+      - redis
 
 networks:
-  local-network:
-    name: local-network
+  dart-local-network:
+    name: dart-local-network
     driver: bridge
 
 volumes:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
-	github.com/openai/openai-go/v3 v3.8.1
+	github.com/openai/openai-go/v3 v3.15.0
 	golang.org/x/net v0.46.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
@@ -52,7 +52,7 @@ require (
 	github.com/redis/go-redis/v9 v9.7.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
-	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/onsi/ginkgo/v2 v2.20.2 h1:7NVCeyIWROIAheY21RLS+3j2bb52W0W82tkberYytp4
 github.com/onsi/ginkgo/v2 v2.20.2/go.mod h1:K9gyxPIlb+aIvnZ8bd9Ak+YP18w3APlR+5coaZoE2ag=
 github.com/onsi/gomega v1.34.2 h1:pNCwDkzrsv7MS9kpaQvVb1aVLahQXyJ/Tv5oAZMI3i8=
 github.com/onsi/gomega v1.34.2/go.mod h1:v1xfxRgk0KIsG+QOdm7p8UosrOzPYRo60fd3B/1Dukc=
-github.com/openai/openai-go/v3 v3.8.1 h1:b+YWsmwqXnbpSHWQEntZAkKciBZ5CJXwL68j+l59UDg=
-github.com/openai/openai-go/v3 v3.8.1/go.mod h1:UOpNxkqC9OdNXNUfpNByKOtB4jAL0EssQXq5p8gO0Xs=
+github.com/openai/openai-go/v3 v3.15.0 h1:hk99rM7YPz+M99/5B/zOQcVwFRLLMdprVGx1vaZ8XMo=
+github.com/openai/openai-go/v3 v3.15.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -116,8 +116,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
-github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=

--- a/internal/controllers/financial_controller.go
+++ b/internal/controllers/financial_controller.go
@@ -39,6 +39,14 @@ type ReportResponse struct {
 	Analysis      json.RawMessage `json:"analysis"`
 }
 
+type ReportSummaryResponse struct {
+	ReceiptNumber string          `json:"receipt_number"`
+	CorpCode      string          `json:"corp_code"`
+	ReportName    string          `json:"report_name"`
+	Summary       json.RawMessage `json:"summary"`
+	RawReport     string          `json:"raw_report"`
+}
+
 // GetCompanies returns a list of all companies
 func (fc *FinancialController) GetCompanies(c *gin.Context) {
 	ctx := c.Request.Context()
@@ -135,6 +143,51 @@ func (fc *FinancialController) GetRawReport(c *gin.Context) {
 	})
 }
 
+// GetReportSummaryByReceiptNumber returns a summary and raw report for a receipt number.
+// TODO: incase raw report is too large, we should handle it by streaming the raw report.
+func (fc *FinancialController) GetReportSummaryByReceiptNumber(c *gin.Context) {
+	receiptNumber := strings.TrimSpace(c.Param("receipt_number"))
+	if receiptNumber == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "receipt_number is required"})
+		return
+	}
+
+	var rawReport models.RawReport
+	err := fc.DB.Model(&models.RawReport{}).Where("receipt_number = ?", receiptNumber).First(&rawReport).Error
+	if err != nil {
+		log.Printf("failed to get raw report by receipt number: %v", err)
+
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Raw report not found"})
+			return
+		}
+
+		log.Printf("failed to get raw report by receipt number: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Something went wrong"})
+		return
+	}
+
+	var analysis models.Analysis
+	err = fc.DB.Model(&models.Analysis{}).Where("raw_report_id = ?", rawReport.ID).First(&analysis).Error
+	if err != nil {
+		log.Printf("failed to get analysis by receipt number: %v", err)
+
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Summary report not found"})
+			return
+		}
+
+		log.Printf("failed to get summary report: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Something went wrong"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"summary":    analysis.Analysis,
+		"raw_report": base64.StdEncoding.EncodeToString(rawReport.BlobData),
+	})
+}
+
 // GetReportsByCorpName returns a JSON list of recent reports for a partial corp_name.
 // This is a non-streaming variant for MCP/Claude clients that expect a simple HTTP response.
 func (fc *FinancialController) GetReportsByCorpName(c *gin.Context) {
@@ -175,8 +228,8 @@ func (fc *FinancialController) GetReportsByCorpName(c *gin.Context) {
 func (fc *FinancialController) GetAllReports(c *gin.Context) {
 	limit := getLimitWithDefault(c, 10)
 	corpCode := c.Query("corp_code")
-	startDate := c.Query("start_date")
-	endDate := c.Query("end_date")
+	startDateStr := c.Query("start_date")
+	endDateStr := c.Query("end_date")
 
 	var reports []ReportResponse
 	scope := fc.DB.
@@ -190,26 +243,33 @@ func (fc *FinancialController) GetAllReports(c *gin.Context) {
 		scope = scope.Where("companies.corp_code = ?", corpCode)
 	}
 
-	if startDate != "" {
-		d, err := time.Parse("2006-01-02", startDate)
+	var startDate time.Time
+	var err error
+
+	if startDateStr != "" {
+		startDate, err = time.Parse("2006-01-02", startDateStr)
 		if err != nil {
 			log.Printf("[WARN] failed to parse start date: %v", err)
 		} else {
-			scope = scope.Where("raw_reports.receipt_number >= ?", d.Format("20060102"))
+			scope = scope.Where("raw_reports.receipt_number >= ?", startDate.Format("20060102"))
 		}
 	}
 
-	if endDate != "" {
-		d, err := time.Parse("2006-01-02", endDate)
+	if endDateStr != "" {
+		d, err := time.Parse("2006-01-02", endDateStr)
 		if err != nil {
 			log.Printf("[WARN] failed to parse end date: %v", err)
 		} else {
+			log.Printf("start date: %v %v %v %v", d, startDate.IsZero(), startDate.After(d), startDate.Equal(d))
+			if !startDate.IsZero() && (startDate.After(d) || startDate.Equal(d)) {
+				d = startDate.Add(24 * time.Hour)
+			}
+
 			scope = scope.Where("raw_reports.receipt_number < ?", d.Format("20060102"))
 		}
 	}
 
-	err := scope.Limit(limit).Scan(&reports).Error
-	if err != nil {
+	if err != scope.Limit(limit).Scan(&reports).Error {
 		log.Printf("failed to get all reports: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Something went wrong"})
 		return

--- a/internal/controllers/financial_controller_test.go
+++ b/internal/controllers/financial_controller_test.go
@@ -369,6 +369,28 @@ var _ = Describe("FinancialController", func() {
 				]
 			}`))
 		})
+
+		It("sets end_date to the next day if it's the same as start_date", func() {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/reports?start_date=2025-11-23&end_date=2025-11-23", nil)
+			resp := httptest.NewRecorder()
+
+			router.ServeHTTP(resp, req)
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			Expect(resp.Body.String()).To(MatchJSON(`{
+				"reports": [
+					{
+						"corp_name": "A 회사",
+						"corp_code": "10000001",
+						"report_name": "Report A",
+						"raw_report_id": 1,
+						"receipt_number": "20251123000001",
+						"receipt_date": "2025-11-23",
+						"report_type": "0",
+						"analysis": {"summary": "a"}
+					}
+				]
+			}`))
+		})
 	})
 
 	Describe("GET /api/v1/reports/:corp_code/:raw_report_id", func() {
@@ -395,6 +417,56 @@ var _ = Describe("FinancialController", func() {
 			}
 			Expect(json.Unmarshal(resp.Body.Bytes(), &body)).To(Succeed())
 			Expect(body.RawReport).To(Equal(base64.StdEncoding.EncodeToString([]byte("doc1"))))
+		})
+	})
+
+	Describe("GET /api/v1/reports/receipt/:receipt_number", func() {
+		receiptNumber := "20251123000001"
+		var rawReport *models.RawReport
+
+		BeforeEach(func() {
+			ctx := context.Background()
+			rawReport = &models.RawReport{
+				ReceiptNumber: receiptNumber,
+				CorpCode:      "10000001",
+				ReportName:    "Report A",
+				BlobData:      []byte("doc1"),
+				BlobSize:      4,
+				JSONData:      json.RawMessage(`{"a":1}`),
+			}
+			createRawReport(dbConn, ctx, rawReport)
+
+			analysis := &models.Analysis{
+				RawReportID: rawReport.ID,
+				Analysis:    json.RawMessage(`{"summary":"a"}`),
+			}
+			createAnalysis(dbConn, ctx, analysis)
+		})
+
+		It("returns summary and raw report for the given receipt number", func() {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/reports/receipt/"+receiptNumber, nil)
+			resp := httptest.NewRecorder()
+
+			router.ServeHTTP(resp, req)
+			Expect(resp.Code).To(Equal(http.StatusOK))
+
+			var body struct {
+				Summary   json.RawMessage `json:"summary"`
+				RawReport string          `json:"raw_report"`
+			}
+			Expect(json.Unmarshal(resp.Body.Bytes(), &body)).To(Succeed())
+			Expect(string(body.Summary)).To(MatchJSON(`{"summary":"a"}`))
+			Expect(body.RawReport).To(Equal(base64.StdEncoding.EncodeToString([]byte("doc1"))))
+		})
+
+		It("returns 404 if receipt number is not found", func() {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/reports/receipt/20251123099999", nil)
+			resp := httptest.NewRecorder()
+
+			router.ServeHTTP(resp, req)
+
+			Expect(resp.Code).To(Equal(http.StatusNotFound))
+			Expect(resp.Body.String()).To(MatchJSON(`{"error": "Raw report not found"}`))
 		})
 	})
 

--- a/internal/pkg/openai/openai.go
+++ b/internal/pkg/openai/openai.go
@@ -352,7 +352,7 @@ func (a *FileAnalyzer) analyzeReportWithBatch(ctx context.Context, contents stri
 }
 
 func (a *FileAnalyzer) waitForBatchCompletion(ctx context.Context, batchID string) (*openai.Batch, error) {
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
 
 	for {
@@ -364,6 +364,8 @@ func (a *FileAnalyzer) waitForBatchCompletion(ctx context.Context, batchID strin
 			if err != nil {
 				return nil, fmt.Errorf("poll batch %s: %w", batchID, err)
 			}
+
+			log.Printf("batch %s status: %s", batchID, current.Status)
 
 			switch current.Status {
 			case openai.BatchStatusCompleted:

--- a/internal/pkg/openai/openai.go
+++ b/internal/pkg/openai/openai.go
@@ -425,6 +425,11 @@ func parseBatchOutput(raw []byte, report interface{}) (interface{}, int64, error
 	return nil, 0, errors.New("no batch output lines found")
 }
 
+func ShowPrompts(docType string, contents string) (string, string) {
+	systemPrompt, prompt, _ := preparePrompt(docType, contents, false)
+	return systemPrompt, prompt
+}
+
 func preparePrompt(docType string, contents string, truncate bool) (string, string, interface{}) {
 	mainPrompt := systemPrompt
 	additionalPrompt := ""
@@ -443,8 +448,8 @@ func preparePrompt(docType string, contents string, truncate bool) (string, stri
 		additionalPrompt = additionalReportSchema
 		report = &Report{}
 	default:
-		mainPrompt += defaultSchema
-		additionalPrompt = defaultAdditionalSchema
+		mainPrompt += fmt.Sprintf("\n%s", defaultSchema)
+		additionalPrompt = fmt.Sprintf("\n%s", defaultAdditionalSchema)
 		report = &DefaultReport{}
 	}
 

--- a/internal/pkg/openai/prompts.go
+++ b/internal/pkg/openai/prompts.go
@@ -1,7 +1,15 @@
 package openai
 
 const (
-	systemPrompt = `너의 임무는 한국 DART 공시 원문에서 숫자/사실을 추출해 정해진 JSON 스키마로만 출력하는 것이다. 추론은 최소화하고, 문서에 명시된 값만 사용하라. 공시 내 중복된 숫자/문장은 제거하되, 표기된 숫자들은 가능한 모두 누락 없이 표시하라. 출력은 반드시 유효한 JSON 한 개만 반환하라. 설명문 금지.`
+	systemPrompt = `너의 임무는 한국 DART 공시 원문에서 사실과 수치를 추출해 정해진 JSON 스키마로만 출력하는 것이다. 추론은 최소화하고, 문서에 명시된 값만 사용하라.
+  모든 공시 유형에 대해 다음 핵심 정보 카테고리는 반드시 세부 속성까지 식별하여 추출하라:
+  1. 재무 및 수치 상세 (Financial Specifics): 총액(Total Amount)뿐만 아니라, 이를 구성하는 단가(Unit Price), 이자율(Rates), 비율(Ratios), 환율 등을 반드시 포함하라. 예: 주식수와 함께 '행사가격' 포함, 계약금액과 함께 '계약보증금률' 포함.
+  2. 인물 및 대상의 속성 (Entity Attributes): 단순 이름/법인명 나열을 넘어, 해당 대상의 직위(Role), 관계(Relation), 상대방 정보(Counterparty)를 함께 명시하라. 예: '김형민' 대신 '대표이사 김형민', '소송' 시 '원고/피고' 구분.
+  3. 시점과 기간 (Time & Period): '공시 제출일'과 구별되는 실제 발생일(Event Date), 계약 기간(Start/End), 만기일을 정확히 추출하라.
+  4. 조건 및 제약 (Conditions & Terms): 단순 사실 외에 보호예수(Lock-up), 옵션(Put/Call), 해지 조건 등 수치에 영향을 주는 제약 사항을 포함하라.
+	5. primary_cause: 이번 보고서가 제출된 핵심 사유를 한 문장으로 요약하라.
+  6. details: 변동이 발생한 모든 주주(임원 포함)의 성명, 관계, 변동일, 구체적 사유, 변동 수량을 포함하여 하나의 자연스러운 문장으로 정리하라.
+  공시 내 단순 중복은 제거하되, 위 핵심 카테고리에 해당하는 수치와 팩트는 생략 없이 모두 표시하라. 출력은 반드시 유효한 JSON 한 개만 반환하라. 설명문 금지.`
 
 	// Securities Issuance Terms
 	securitiesIssuanceTermsSchema = `
@@ -207,6 +215,38 @@ const (
 		summary: string,
 		related_companies: [string] (연관된 회사 이름 배열, 없을 경우 빈 배열 []),
 		schema_suggestion: string (추출된 데이터에 적합한 JSON 스키마 예시, 아래 Output Format 참고)
+		primary_cause: string,
+		details: string,
+		data_extraction: {
+    financial_specifics: [
+      {
+        item: string,
+        value: string,
+        unit: string,
+        details: string
+      }
+    ],
+    entity_attributes: [
+      {
+        name: string,
+        role: string,
+        relationship: string,
+        identifier: string
+      }
+    ],
+    time_period: [
+      {
+        label: string,
+        date: string,
+        note: string
+      }
+    ],
+    conditions_terms: [
+      {
+        term_name: string,
+        content: string
+      }
+    ]
 	}
 	## Output Format
 		- 항상 아래의 필드명 및 순서(company_name, date, type, summary, related_companies, schema_suggestion)에 맞추어 유효한 JSON 오브젝트 하나만 출력.

--- a/internal/pkg/openai/structs.go
+++ b/internal/pkg/openai/structs.go
@@ -163,10 +163,45 @@ type CreditRating struct {
 }
 
 type DefaultReport struct {
-	CompanyName      string   `json:"company_name"`
-	Date             string   `json:"date"`
-	Type             string   `json:"type"`
-	Summary          string   `json:"summary"`
-	RelatedCompanies []string `json:"related_companies"`
-	SchemaSuggestion string   `json:"schema_suggestion"`
+	CompanyName      string         `json:"company_name"`
+	Date             string         `json:"date"`
+	Type             string         `json:"type"`
+	Summary          string         `json:"summary"`
+	PrimaryCause     string         `json:"primary_cause"`
+	Details          string         `json:"details"`
+	RelatedCompanies []string       `json:"related_companies"`
+	SchemaSuggestion string         `json:"schema_suggestion"`
+	DataExtraction   DataExtraction `json:"data_extraction"`
+}
+
+type DataExtraction struct {
+	FinancialSpecifics []FinancialSpecific `json:"financial_specifics"`
+	EntityAttributes   []EntityAttribute   `json:"entity_attributes"`
+	TimePeriod         []TimePeriod        `json:"time_period"`
+	ConditionsTerms    []ConditionsTerm    `json:"conditions_terms"`
+}
+
+type FinancialSpecific struct {
+	Item    string `json:"item"`
+	Value   string `json:"value"`
+	Unit    string `json:"unit"`
+	Details string `json:"details"`
+}
+
+type EntityAttribute struct {
+	Name         string `json:"name"`
+	Role         string `json:"role"`
+	Relationship string `json:"relationship"`
+	Identifier   string `json:"identifier"`
+}
+
+type TimePeriod struct {
+	Label string `json:"label"`
+	Date  string `json:"date"`
+	Note  string `json:"note"`
+}
+
+type ConditionsTerm struct {
+	TermName string `json:"term_name"`
+	Content  string `json:"content"`
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -50,8 +50,17 @@ func SetupRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 		// Raw reports endpoints
 		api.GET("/reports/:corp_code/:raw_report_id", financialController.GetRawReport)
 
+		// Summary + raw report by receipt number
+		api.GET("/reports/receipt/:receipt_number", financialController.GetReportSummaryByReceiptNumber)
+
+		// Summary + raw report by receipt number
+		api.GET("/mcp/reports/receipt/:receipt_number", financialController.GetReportSummaryByReceiptNumber)
+
 		// Reports endpoints
 		api.GET("/reports", financialController.GetAllReports)
+
+		// Reports endpoints
+		api.GET("/mcp/reports", financialController.GetAllReports)
 	}
 
 	return router

--- a/internal/tasks/dry-run.go
+++ b/internal/tasks/dry-run.go
@@ -1,0 +1,70 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"kosis/internal/pkg/dart"
+	"kosis/internal/pkg/openai"
+	"kosis/internal/pkg/xbrl"
+	"log"
+	"strings"
+)
+
+func FetchReportDryRun(dartClient *dart.DartClient, fileAnalyzer *openai.FileAnalyzer, receiptNumber string) error {
+	rawDocument, err := dartClient.GetDocument(receiptNumber)
+	if err == dart.ErrDocumentNotFound {
+		log.Printf("document not found: %s", receiptNumber)
+		return nil
+	}
+
+	doc, err := xbrl.ParseXBRL([]byte(rawDocument))
+	if err != nil {
+		log.Printf("failed to parse XBRL document: %v", err)
+		return err
+	}
+
+	j, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		log.Printf("failed to marshal JSON: %v", err)
+		return err
+	}
+
+	reportType := ""
+	if strings.Contains(doc.ReportTitle, "분기보고서") || strings.Contains(doc.ReportTitle, "사업보고서") || strings.Contains(doc.ReportTitle, "반기보고서") {
+		reportType = "report"
+	} else {
+		log.Printf("unknown report type: %s", doc.ReportTitle)
+	}
+
+	reportLength := len(j)
+	var analysis interface{}
+	var usedTokens int64
+	ctx := context.Background()
+
+	systemPrompt, prompt := openai.ShowPrompts(reportType, string(j))
+	log.Printf("System: %s\n User: %s", systemPrompt, prompt)
+
+	if reportLength > openai.PreviewByteLimit {
+		log.Printf("analyzing report with batch API: %s", receiptNumber)
+		analysis, usedTokens, err = fileAnalyzer.AnalyzeReportBatch(ctx, string(j), reportType)
+		if err != nil {
+			log.Printf("failed to analyze report: %v", err)
+			return err
+		}
+	} else {
+		analysis, usedTokens, err = fileAnalyzer.AnalyzeReport(ctx, string(j), reportType)
+		if err != nil {
+			log.Printf("failed to analyze report: %v", err)
+			return err
+		}
+	}
+
+	analysisJSON, err := json.MarshalIndent(analysis, "", "  ")
+	if err != nil {
+		log.Printf("failed to marshal analysis: %v", err)
+		return err
+	}
+
+	log.Printf("analyzed report: %s, %d, %s", receiptNumber, usedTokens, string(analysisJSON))
+	return nil
+}

--- a/internal/tasks/processor.go
+++ b/internal/tasks/processor.go
@@ -155,13 +155,8 @@ func (p *TaskProcessor) HandleFetchReportsTask(ctx context.Context, t *asynq.Tas
 					return err
 				}
 
-				analysis = &openai.DefaultReport{
-					CompanyName:      v.CompanyName,
-					Date:             v.Date,
-					Type:             v.Type,
-					Summary:          v.Summary,
-					RelatedCompanies: v.RelatedCompanies,
-				}
+				v.SchemaSuggestion = ""
+				analysis = v
 			}
 		}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds containerization and expands report retrieval/analysis across API, MCP, and worker.
> 
> - **DevOps**: New `Dockerfile_api`, `Dockerfile_worker`, and `docker-compose.yml`; ignore `.env.docker`; README/Makefile updates with `run-worker-cli` and compose usage
> - **API**: New `GET /api/v1/reports/receipt/:receipt_number` (+ MCP mirror) returning summary + raw; exposes `/mcp/reports` variants; improves `GET /reports` date filtering (adjust `end_date` when equal to `start_date`)
> - **MCP**: Base URL set to `/api/v1`; rename tool to `disclosures_reports_by_corp_name`; add tools `reports_summary_all_companies` and `reports_summary_and_raw_by_receipt_number`
> - **Worker**: Add dry-run CLI; on startup, delete existing fetch-report tasks before enqueue and set 2h timeout; introduce inspector usage
> - **OpenAI**: Extend default report schema (add `primary_cause`, `details`, `data_extraction`), expose `ShowPrompts`, tweak prompts, increase batch poll interval with status logging
> - **Tests/Deps**: Add controller tests for new routes/date logic; bump `openai-go` and `gjson` versions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60bf1f6c3559264c57ebb91a5c33ccef6e709ef5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->