### PR TITLE
⚡ Batch Insert Analysis Results

### DIFF
--- a/internal/tasks/processor.go
+++ b/internal/tasks/processor.go
@@ -52,6 +52,7 @@ func (p *TaskProcessor) HandleFetchReportsTask(ctx context.Context, t *asynq.Tas
 	}
 
 	totalUsedTokens := int64(0)
+	var analyses []models.Analysis
 	for _, rawReport := range rawReports {
 		count, err := gorm.G[models.RawReport](p.DB).Where("receipt_number = ?", rawReport.RceptNo).Count(ctx, "id")
 		if err != nil {
@@ -166,21 +167,28 @@ func (p *TaskProcessor) HandleFetchReportsTask(ctx context.Context, t *asynq.Tas
 			continue
 		}
 
-		result = gorm.WithResult()
-		err = gorm.G[models.Analysis](p.DB, result).Create(ctx, &models.Analysis{
+		analyses = append(analyses, models.Analysis{
 			RawReportID: rawReport.ID,
 			UsedTokens:  usedTokens,
 			Analysis:    analysisJSON,
 		})
-		if err != nil {
-			return err
-		}
 
-		log.Printf("stored raw report: %s, %s, %d, %d", rawReport.ReceiptNumber, rawReport.CorpCode, rawReport.BlobSize, usedTokens)
+		log.Printf("processed raw report: %s, %s, %d, %d", rawReport.ReceiptNumber, rawReport.CorpCode, rawReport.BlobSize, usedTokens)
 
 		totalUsedTokens += usedTokens
 
 		log.Printf("total used tokens: %d", totalUsedTokens)
+	}
+
+	if len(analyses) > 0 {
+		log.Printf("storing %d analyses in batch", len(analyses))
+		result := gorm.WithResult()
+		err := gorm.G[models.Analysis](p.DB, result).Create(ctx, &analyses)
+		if err != nil {
+			log.Printf("failed to store analyses in batch: %v", err)
+			return err
+		}
+		log.Printf("successfully stored %d analyses in batch", len(analyses))
 	}
 
 	log.Println("Reports fetched successfully")

--- a/internal/tasks/processor.go
+++ b/internal/tasks/processor.go
@@ -52,6 +52,7 @@ func (p *TaskProcessor) HandleFetchReportsTask(ctx context.Context, t *asynq.Tas
 	}
 
 	totalUsedTokens := int64(0)
+	var analyses []models.Analysis
 	for _, rawReport := range rawReports {
 		count, err := gorm.G[models.RawReport](p.DB).Where("receipt_number = ?", rawReport.RceptNo).Count(ctx, "id")
 		if err != nil {
@@ -166,21 +167,28 @@ func (p *TaskProcessor) HandleFetchReportsTask(ctx context.Context, t *asynq.Tas
 			continue
 		}
 
-		result = gorm.WithResult()
-		err = gorm.G[models.Analysis](p.DB, result).Create(ctx, &models.Analysis{
+		analyses = append(analyses, models.Analysis{
 			RawReportID: rawReport.ID,
 			UsedTokens:  usedTokens,
 			Analysis:    analysisJSON,
 		})
-		if err != nil {
-			return err
-		}
 
-		log.Printf("stored raw report: %s, %s, %d, %d", rawReport.ReceiptNumber, rawReport.CorpCode, rawReport.BlobSize, usedTokens)
+		log.Printf("processed raw report: %s, %s, %d, %d", rawReport.ReceiptNumber, rawReport.CorpCode, rawReport.BlobSize, usedTokens)
 
 		totalUsedTokens += usedTokens
 
 		log.Printf("total used tokens: %d", totalUsedTokens)
+	}
+
+	if len(analyses) > 0 {
+		log.Printf("storing %d analyses in batch", len(analyses))
+		result := gorm.WithResult()
+		err := gorm.G[models.Analysis](p.DB, result).CreateInBatches(ctx, &analyses, len(analyses))
+		if err != nil {
+			log.Printf("failed to store analyses in batch: %v", err)
+			return err
+		}
+		log.Printf("successfully stored %d analyses in batch", len(analyses))
 	}
 
 	log.Println("Reports fetched successfully")


### PR DESCRIPTION
Improved the performance of report processing by batching the insertion of analysis results. Previously, analysis results were inserted one by one inside a loop, which caused significant transaction overhead. Now, they are collected and inserted in a single batch operation after the loop finishes. Logging has also been updated to accurately reflect that a report has been processed but not yet persisted until the final batch operation.

---
*PR created automatically by Jules for task [16190395597910121384](https://jules.google.com/task/16190395597910121384) started by @styner32*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence behavior by deferring `Analysis` inserts until after the loop, which could drop analyses if the task fails before the final batch write and may increase memory usage for large report sets.
> 
> **Overview**
> Improves report-processing throughput by **collecting `models.Analysis` rows during the fetch/analyze loop and inserting them in a single batch** at the end, instead of writing each analysis per iteration.
> 
> Updates logging to reflect the new flow (reports are "processed" before persistence) and adds batch insert success/failure logs for the analysis write step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d529d5ad95507b4be6dbfaaafd0fc37cd3413dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->