### PR TITLE
🛡️ Sentinel: [HIGH] Fix overly permissive CORS configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [Overly Permissive CORS Configuration]
+**Vulnerability:** The API allowed `Access-Control-Allow-Origin: "*"` combined with `Access-Control-Allow-Credentials: "true"` in the global Gin middleware.
+**Learning:** This is a severe security risk (CORS misconfiguration) that could allow malicious websites to perform Cross-Site Request Forgery (CSRF) via credentialed requests, compromising user data or actions. Modern browsers typically reject this combination, but relying on browser behavior is insufficient defense.
+**Prevention:** Implement strict Origin validation by checking the incoming `Origin` header against a whitelist of allowed domains loaded from configuration. Do not blindly reflect origins or use wildcard `*` when credentials are permitted.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module kosis
 
-go 1.24
+go 1.24.0
+
+toolchain go1.24.3
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.3

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	DartAPIKey   string
 	KosisAPIKey  string
 	OpenAIAPIKey string
+	AllowedOrigins string
 }
 
 // LoadConfig reads configuration from environment variables (.env file)
@@ -26,9 +27,10 @@ func LoadConfig() (*Config, error) {
 	return &Config{
 		DatabaseURL:  getEnv("DATABASE_URL", ""),
 		RedisURL:     getEnv("REDIS_URL", ""),
-		DartAPIKey:   getEnv("DART_API_KEY", ""),
-		KosisAPIKey:  getEnv("KOSIS_API_KEY", ""),
-		OpenAIAPIKey: getEnv("OPENAI_API_KEY", ""),
+		DartAPIKey:     getEnv("DART_API_KEY", ""),
+		KosisAPIKey:    getEnv("KOSIS_API_KEY", ""),
+		OpenAIAPIKey:   getEnv("OPENAI_API_KEY", ""),
+		AllowedOrigins: getEnv("ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:5173"),
 	}, nil
 }
 

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"kosis/internal/config"
 	"kosis/internal/controllers"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -15,10 +16,31 @@ func SetupRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	// Set up Gin router
 	router := gin.Default()
 
+	// Parse allowed origins
+	var allowedOrigins []string
+	if cfg != nil && cfg.AllowedOrigins != "" {
+		allowedOrigins = strings.Split(cfg.AllowedOrigins, ",")
+	}
+
 	// CORS middleware
 	router.Use(func(c *gin.Context) {
-		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
-		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+		origin := c.Request.Header.Get("Origin")
+
+		allowed := false
+		if origin != "" {
+			for _, o := range allowedOrigins {
+				if origin == strings.TrimSpace(o) {
+					allowed = true
+					break
+				}
+			}
+		}
+
+		if allowed {
+			c.Writer.Header().Set("Access-Control-Allow-Origin", origin)
+			c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+		}
+
 		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT, DELETE")
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The API allowed `Access-Control-Allow-Origin: "*"` combined with `Access-Control-Allow-Credentials: "true"` in the global Gin middleware.
🎯 Impact: This is a severe security risk (CORS misconfiguration) that could allow malicious websites to perform Cross-Site Request Forgery (CSRF) via credentialed requests, compromising user data or actions. Modern browsers typically reject this combination, but relying on browser behavior is insufficient defense.
🔧 Fix: Implemented strict Origin validation by checking the incoming `Origin` header against a whitelist of allowed domains loaded from configuration. Do not blindly reflect origins or use wildcard `*` when credentials are permitted.
✅ Verification: Ran `go build ./...` and `go test ./...` to verify the codebase compiles and passes tests. Reviewed manual modifications and received correct rating from code review tool.

---
*PR created automatically by Jules for task [17497941837896772394](https://jules.google.com/task/17497941837896772394) started by @styner32*