### PR TITLE
🛡️ Sentinel: [HIGH] Fix overly permissive CORS configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [Overly Permissive CORS Configuration]
+**Vulnerability:** The API allowed `Access-Control-Allow-Origin: *` while simultaneously setting `Access-Control-Allow-Credentials: true`. This combination is a security risk as it allows any origin to make authenticated cross-origin requests using the user's credentials, potentially exposing sensitive data.
+**Learning:** Hardcoding `*` for allowed origins alongside credentials allows for CSRF-like attacks where a malicious site can read responses using a user's session.
+**Prevention:** Implement a dynamic origin validation mechanism that checks incoming origins against an explicit, configurable allowlist before setting the `Access-Control-Allow-Origin` and `Access-Control-Allow-Credentials` headers.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The API allowed `Access-Control-Allow-Origin: *` while simultaneously setting `Access-Control-Allow-Credentials: true`. This combination is a security risk as it allows any origin to make authenticated cross-origin requests using the user's credentials, potentially exposing sensitive data.
 **Learning:** Hardcoding `*` for allowed origins alongside credentials allows for CSRF-like attacks where a malicious site can read responses using a user's session.
 **Prevention:** Implement a dynamic origin validation mechanism that checks incoming origins against an explicit, configurable allowlist before setting the `Access-Control-Allow-Origin` and `Access-Control-Allow-Credentials` headers.
+
+## 2026-03-13 - [Wildcard CORS + reflect Origin + credentials]
+**Vulnerability:** Treating `ALLOWED_ORIGINS=*` by reflecting the request `Origin` and setting `Access-Control-Allow-Credentials: true` is worse than `*` + credentials (browsers reject the latter). Reflected origin + credentials is accepted, so any site could perform credentialed cross-origin requests.
+**Prevention:** If open CORS is required, use literal `Access-Control-Allow-Origin: *` and omit `Access-Control-Allow-Credentials`. For cookies/auth cross-origin, use an explicit origin allowlist and reflect only listed origins.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	DartAPIKey     string
 	KosisAPIKey    string
 	OpenAIAPIKey   string
+	// Comma-separated origins, or exactly "*" for open CORS (no credentials). For credentialed CORS, list explicit origins only.
 	AllowedOrigins string
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,11 +8,12 @@ import (
 
 // Config holds all configuration for the application
 type Config struct {
-	DatabaseURL  string // Consolidated DB Connection URL
-	RedisURL     string
-	DartAPIKey   string
-	KosisAPIKey  string
-	OpenAIAPIKey string
+	DatabaseURL    string // Consolidated DB Connection URL
+	RedisURL       string
+	DartAPIKey     string
+	KosisAPIKey    string
+	OpenAIAPIKey   string
+	AllowedOrigins string
 }
 
 // LoadConfig reads configuration from environment variables (.env file)
@@ -24,11 +25,12 @@ func LoadConfig() (*Config, error) {
 	}
 
 	return &Config{
-		DatabaseURL:  getEnv("DATABASE_URL", ""),
-		RedisURL:     getEnv("REDIS_URL", ""),
-		DartAPIKey:   getEnv("DART_API_KEY", ""),
-		KosisAPIKey:  getEnv("KOSIS_API_KEY", ""),
-		OpenAIAPIKey: getEnv("OPENAI_API_KEY", ""),
+		DatabaseURL:    getEnv("DATABASE_URL", ""),
+		RedisURL:       getEnv("REDIS_URL", ""),
+		DartAPIKey:     getEnv("DART_API_KEY", ""),
+		KosisAPIKey:    getEnv("KOSIS_API_KEY", ""),
+		OpenAIAPIKey:   getEnv("OPENAI_API_KEY", ""),
+		AllowedOrigins: getEnv("ALLOWED_ORIGINS", ""),
 	}, nil
 }
 

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"kosis/internal/config"
 	"kosis/internal/controllers"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -15,10 +16,44 @@ func SetupRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	// Set up Gin router
 	router := gin.Default()
 
+	// Parse allowed origins
+	var allowedOrigins []string
+	for _, o := range strings.Split(cfg.AllowedOrigins, ",") {
+		o = strings.TrimSpace(o)
+		if o != "" {
+			allowedOrigins = append(allowedOrigins, o)
+		}
+	}
+
 	// CORS middleware
 	router.Use(func(c *gin.Context) {
-		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
-		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+		origin := c.Request.Header.Get("Origin")
+
+		// Check if the origin is in the allowed list
+		allowed := false
+		if cfg.AllowedOrigins == "*" {
+			allowed = true
+		} else {
+			for _, o := range allowedOrigins {
+				if o == origin {
+					allowed = true
+					break
+				}
+			}
+		}
+
+		if allowed {
+			// If allowed, always reflect the origin (if present) to support credentials
+			// Modern browsers reject Access-Control-Allow-Origin: * when Access-Control-Allow-Credentials: true
+			if origin != "" {
+				c.Writer.Header().Set("Access-Control-Allow-Origin", origin)
+			} else if cfg.AllowedOrigins == "*" {
+				c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+			}
+
+			c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+		}
+
 		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT, DELETE")
 

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -16,12 +16,16 @@ func SetupRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	// Set up Gin router
 	router := gin.Default()
 
-	// Parse allowed origins
+	// Parse allowed origins (trimmed single "*" means open CORS without credentials only)
+	allowedOriginsRaw := strings.TrimSpace(cfg.AllowedOrigins)
+	wildcardOpen := allowedOriginsRaw == "*"
 	var allowedOrigins []string
-	for _, o := range strings.Split(cfg.AllowedOrigins, ",") {
-		o = strings.TrimSpace(o)
-		if o != "" {
-			allowedOrigins = append(allowedOrigins, o)
+	if !wildcardOpen {
+		for _, o := range strings.Split(cfg.AllowedOrigins, ",") {
+			o = strings.TrimSpace(o)
+			if o != "" && o != "*" {
+				allowedOrigins = append(allowedOrigins, o)
+			}
 		}
 	}
 
@@ -29,29 +33,25 @@ func SetupRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	router.Use(func(c *gin.Context) {
 		origin := c.Request.Header.Get("Origin")
 
-		// Check if the origin is in the allowed list
-		allowed := false
-		if cfg.AllowedOrigins == "*" {
-			allowed = true
+		if wildcardOpen {
+			// * alone: allow any origin via literal * and NEVER credentials.
+			// Reflecting arbitrary Origin + credentials would let any site make credentialed requests.
+			c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
 		} else {
+			// Allow-Origin reflects request Origin; caches must partition by Origin or they
+			// could serve one origin's CORS headers to another (RFC 9110 / CORS).
+			c.Writer.Header().Add("Vary", "Origin")
+			allowed := false
 			for _, o := range allowedOrigins {
 				if o == origin {
 					allowed = true
 					break
 				}
 			}
-		}
-
-		if allowed {
-			// If allowed, always reflect the origin (if present) to support credentials
-			// Modern browsers reject Access-Control-Allow-Origin: * when Access-Control-Allow-Credentials: true
-			if origin != "" {
+			if allowed && origin != "" {
 				c.Writer.Header().Set("Access-Control-Allow-Origin", origin)
-			} else if cfg.AllowedOrigins == "*" {
-				c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+				c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 			}
-
-			c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 		}
 
 		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")

--- a/internal/routes/routes_test.go
+++ b/internal/routes/routes_test.go
@@ -1,0 +1,91 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"kosis/internal/config"
+	"gorm.io/gorm"
+)
+
+func TestCORS(t *testing.T) {
+	// Create a mock DB and config
+	db := &gorm.DB{}
+	cfg := &config.Config{
+		AllowedOrigins: "http://localhost:3000, https://example.com ",
+	}
+
+	router := SetupRouter(db, cfg)
+
+	tests := []struct {
+		name           string
+		origin         string
+		expectedStatus int
+		expectedOrigin string
+	}{
+		{
+			name:           "Allowed Origin",
+			origin:         "http://localhost:3000",
+			expectedStatus: http.StatusOK,
+			expectedOrigin: "http://localhost:3000",
+		},
+		{
+			name:           "Another Allowed Origin with whitespace in config",
+			origin:         "https://example.com",
+			expectedStatus: http.StatusOK,
+			expectedOrigin: "https://example.com",
+		},
+		{
+			name:           "Disallowed Origin",
+			origin:         "http://malicious.com",
+			expectedStatus: http.StatusOK,
+			expectedOrigin: "", // Should not be set
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/health", nil)
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != tc.expectedStatus {
+				t.Errorf("Expected status %d, got %d", tc.expectedStatus, w.Code)
+			}
+
+			originHeader := w.Header().Get("Access-Control-Allow-Origin")
+			if originHeader != tc.expectedOrigin {
+				t.Errorf("Expected Origin %q, got %q", tc.expectedOrigin, originHeader)
+			}
+		})
+	}
+}
+
+func TestCORSWildcard(t *testing.T) {
+	// Create a mock DB and config
+	db := &gorm.DB{}
+	cfg := &config.Config{
+		AllowedOrigins: "*",
+	}
+
+	router := SetupRouter(db, cfg)
+
+	req, _ := http.NewRequest("GET", "/health", nil)
+	req.Header.Set("Origin", "http://malicious.com")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	originHeader := w.Header().Get("Access-Control-Allow-Origin")
+	if originHeader != "http://malicious.com" { // It should reflect the origin now when wildcard is used
+		t.Errorf("Expected Origin 'http://malicious.com', got %q", originHeader)
+	}
+}

--- a/internal/routes/routes_test.go
+++ b/internal/routes/routes_test.go
@@ -61,17 +61,21 @@ func TestCORS(t *testing.T) {
 			if originHeader != tc.expectedOrigin {
 				t.Errorf("Expected Origin %q, got %q", tc.expectedOrigin, originHeader)
 			}
+			if tc.expectedOrigin != "" {
+				if w.Header().Get("Access-Control-Allow-Credentials") != "true" {
+					t.Errorf("allowlisted origin should set Allow-Credentials true")
+				}
+			}
+			if w.Header().Get("Vary") != "Origin" {
+				t.Errorf("allowlist CORS must set Vary: Origin for cache safety; got %q", w.Header().Get("Vary"))
+			}
 		})
 	}
 }
 
 func TestCORSWildcard(t *testing.T) {
-	// Create a mock DB and config
 	db := &gorm.DB{}
-	cfg := &config.Config{
-		AllowedOrigins: "*",
-	}
-
+	cfg := &config.Config{AllowedOrigins: "*"}
 	router := SetupRouter(db, cfg)
 
 	req, _ := http.NewRequest("GET", "/health", nil)
@@ -83,9 +87,15 @@ func TestCORSWildcard(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status 200, got %d", w.Code)
 	}
-
-	originHeader := w.Header().Get("Access-Control-Allow-Origin")
-	if originHeader != "http://malicious.com" { // It should reflect the origin now when wildcard is used
-		t.Errorf("Expected Origin 'http://malicious.com', got %q", originHeader)
+	// Wildcard must be literal * without credentials — never reflect attacker Origin + credentials
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("Expected Access-Control-Allow-Origin %q, got %q", "*", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Errorf("wildcard open CORS must not send Allow-Credentials; got %q", got)
+	}
+	// Literal * is same for every request; Vary: Origin not required for CORS caching
+	if got := w.Header().Get("Vary"); got != "" {
+		t.Errorf("wildcard CORS should not require Vary: Origin; got %q", got)
 	}
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The API returned `Access-Control-Allow-Origin: *` while simultaneously setting `Access-Control-Allow-Credentials: true`. This is fundamentally insecure and specifically rejected by modern browsers, allowing malicious actors to exploit this if the credentials header wasn't strictly enforced.
🎯 Impact: Left unaddressed, it creates a vector for Cross-Site Request Forgery (CSRF) and enables unauthorized cross-origin requests using users' session data if not mitigated by browser defaults.
🔧 Fix: Updated the CORS middleware to parse a comma-separated `ALLOWED_ORIGINS` environment variable. It now matches incoming `Origin` headers against the allowed list and safely reflects the incoming origin, satisfying browser requirements for credentialed requests.
✅ Verification: Covered by a new test suite explicitly verifying allowed, disallowed, and wildcard origin behavior. Tested locally using `go test ./internal/routes/...`.

---
*PR created automatically by Jules for task [10355732307632469443](https://jules.google.com/task/10355732307632469443) started by @styner32*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request/response security headers for all routes; a misconfigured `ALLOWED_ORIGINS` value could break browser clients or unintentionally broaden access despite added tests.
> 
> **Overview**
> Fixes overly permissive credentialed CORS by replacing `Access-Control-Allow-Origin: *` with an allowlist-driven policy based on a new `ALLOWED_ORIGINS` config value, reflecting the request `Origin` only when allowed (with special-case wildcard handling).
> 
> Adds route-level tests covering allowed, disallowed, and wildcard origin behavior, and updates `go.mod` to pin `go 1.24.0` and specify `toolchain go1.24.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03bff8090c458390c0d66a2e44053ef9a28431cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->