### PR TITLE
🛡️ Sentinel: [HIGH] Fix GORM negative limit DoS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 ## 2026-03-13 - [Wildcard CORS + reflect Origin + credentials]
 **Vulnerability:** Treating `ALLOWED_ORIGINS=*` by reflecting the request `Origin` and setting `Access-Control-Allow-Credentials: true` is worse than `*` + credentials (browsers reject the latter). Reflected origin + credentials is accepted, so any site could perform credentialed cross-origin requests.
 **Prevention:** If open CORS is required, use literal `Access-Control-Allow-Origin: *` and omit `Access-Control-Allow-Credentials`. For cookies/auth cross-origin, use an explicit origin allowlist and reflect only listed origins.
+
+## 2026-03-14 - [GORM Negative Limit DoS Vulnerability]
+**Vulnerability:** GORM translates negative limit values (like `Limit(-1)`) to "no limit". When an API exposes pagination limits derived from user input without validation, attackers can request negative limits to force the database to fetch all records, causing memory exhaustion and Denial of Service (DoS).
+**Learning:** Even strong typing doesn't prevent logic abuse. GORM's API design makes it easy to accidentally allow unbounded queries if user inputs for limits aren't explicitly bounded on both ends.
+**Prevention:** Always validate integer inputs used for database query limits to ensure they are strictly positive and bounded by a reasonable maximum limit before passing them to the database layer (e.g., `if limit <= 0 || limit > MAX_ALLOWED`).

--- a/internal/controllers/financial_controller.go
+++ b/internal/controllers/financial_controller.go
@@ -315,6 +315,14 @@ func getLimitWithDefault(c *gin.Context, defaultValue int) int {
 			log.Printf("failed to parse limit: %v, using default value: %d", err, defaultValue)
 			return defaultValue
 		}
+
+		// 🛡️ Sentinel: Prevent resource exhaustion / DoS
+		// GORM translates negative limit to "no limit", which could fetch massive rows.
+		// Large values could cause memory exhaustion.
+		if limit <= 0 || limit > 100 {
+			log.Printf("Security warning: Invalid limit %d requested, falling back to %d", limit, defaultValue)
+			return defaultValue
+		}
 	}
 	return limit
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: GORM Negative Limit DoS Vulnerability
🎯 Impact: Attackers could bypass pagination controls by supplying negative limit values or excessively large values to API endpoints. Because GORM translates negative limits into "no limit" unbounded queries, this could exhaust application memory, spike database load, and cause Denial of Service (DoS).
🔧 Fix: Implemented strict validation and bounds checking on the user-supplied `limit` parameter in `getLimitWithDefault`. Now limits must be greater than 0 and less than or equal to 100, otherwise it gracefully falls back to the `defaultValue`.
✅ Verification: Tests in `internal/controllers/...` have been run and confirm that standard limit overrides correctly apply and the system avoids returning infinite payload lengths.

A new entry was also added to `.jules/sentinel.md` outlining the learnings and prevention mechanisms for this vulnerability class.

---
*PR created automatically by Jules for task [8922536710791564356](https://jules.google.com/task/8922536710791564356) started by @styner32*