### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix GORM negative limit DoS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 ## 2026-03-13 - [Wildcard CORS + reflect Origin + credentials]
 **Vulnerability:** Treating `ALLOWED_ORIGINS=*` by reflecting the request `Origin` and setting `Access-Control-Allow-Credentials: true` is worse than `*` + credentials (browsers reject the latter). Reflected origin + credentials is accepted, so any site could perform credentialed cross-origin requests.
 **Prevention:** If open CORS is required, use literal `Access-Control-Allow-Origin: *` and omit `Access-Control-Allow-Credentials`. For cookies/auth cross-origin, use an explicit origin allowlist and reflect only listed origins.
+
+## 2024-05-20 - [GORM Negative Limit DoS]
+**Vulnerability:** The application used user-supplied `limit` parameters directly in GORM queries without enforcing lower or upper bounds. Attackers could supply a negative value like `?limit=-1`, which GORM translates to "no limit," fetching all rows from the database. This could cause Denial of Service (DoS) and application Out-Of-Memory (OOM) errors.
+**Learning:** Pagination parameters must always be strictly validated and bounded because ORMs like GORM have internal logic (e.g., negative limits bypassing constraints) that can turn a seemingly harmless input into a full table scan.
+**Prevention:** Always enforce a sensible lower limit (e.g., `> 0`) and an upper bound limit (e.g., `max 100`) before passing pagination values to any database querying function.

--- a/internal/controllers/financial_controller.go
+++ b/internal/controllers/financial_controller.go
@@ -316,5 +316,16 @@ func getLimitWithDefault(c *gin.Context, defaultValue int) int {
 			return defaultValue
 		}
 	}
+
+	// 🛡️ Sentinel: Security fix to prevent DoS via negative limits
+	// GORM interprets negative limits as 'no limit', potentially loading entire tables
+	if limit <= 0 {
+		limit = defaultValue
+	}
+	// 🛡️ Sentinel: Enforce an upper bound on limits to prevent memory exhaustion
+	if limit > 100 {
+		limit = 100
+	}
+
 	return limit
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unbounded pagination parameter (`limit`) passed to GORM queries. GORM translates negative limit values (like `?limit=-1`) into "no limit", which can lead to full table scans.
🎯 **Impact:** An attacker could exploit this to trigger Denial of Service (DoS) conditions and potentially exhaust application memory (OOM) by fetching unconstrained numbers of rows from the database.
🔧 **Fix:** Implemented strict boundaries in `getLimitWithDefault`: if the limit is <= 0, it falls back to the default value. If the limit exceeds 100, it is capped at 100. Added a journal entry detailing this GORM security pattern to `.jules/sentinel.md`.
✅ **Verification:** Verified by running the test suite on `internal/controllers` and `internal/routes` using `go test ./...` and ensuring no regressions occurred.

---
*PR created automatically by Jules for task [1638376075896723039](https://jules.google.com/task/1638376075896723039) started by @styner32*