### PR TITLE
🛡️ Sentinel: [HIGH] Fix GORM Unbounded Pagination Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 ## 2026-03-13 - [Wildcard CORS + reflect Origin + credentials]
 **Vulnerability:** Treating `ALLOWED_ORIGINS=*` by reflecting the request `Origin` and setting `Access-Control-Allow-Credentials: true` is worse than `*` + credentials (browsers reject the latter). Reflected origin + credentials is accepted, so any site could perform credentialed cross-origin requests.
 **Prevention:** If open CORS is required, use literal `Access-Control-Allow-Origin: *` and omit `Access-Control-Allow-Credentials`. For cookies/auth cross-origin, use an explicit origin allowlist and reflect only listed origins.
+
+## 2026-03-17 - [GORM Negative Limit DoS Vulnerability]
+**Vulnerability:** GORM translates negative limit values (like `Limit(-1)`) to 'no limit'. If a user supplies a negative limit parameter (e.g., `?limit=-1`), the application fetches all records from the database instead of paginating, causing a Denial of Service (DoS) and memory exhaustion.
+**Learning:** Default parameter parsing does not protect against negative values, and GORM's behavior with negative limits creates an unexpected security gap in data fetching endpoints.
+**Prevention:** Always strictly validate and bound pagination parameters before passing them to GORM. Ensure limits are strictly positive (`> 0`) and capped to a sensible maximum (e.g., 1000) to prevent excessive data retrieval.

--- a/internal/controllers/financial_controller.go
+++ b/internal/controllers/financial_controller.go
@@ -316,5 +316,16 @@ func getLimitWithDefault(c *gin.Context, defaultValue int) int {
 			return defaultValue
 		}
 	}
+
+	// Security: Prevent negative limits (GORM interprets negative as no limit, causing DoS)
+	if limit <= 0 {
+		return defaultValue
+	}
+
+	// Security: Cap maximum limit to prevent memory exhaustion
+	if limit > 1000 {
+		return 1000
+	}
+
 	return limit
 }


### PR DESCRIPTION
🛡️ **Sentinel Security Fix**

🚨 **Severity:** HIGH
💡 **Vulnerability:** GORM interprets negative limits (e.g., `.Limit(-1)`) as "no limit". If a user supplies a negative `limit` parameter, it bypasses pagination entirely.
🎯 **Impact:** An attacker could supply `?limit=-1` to endpoints like `/api/v1/companies` or `/api/v1/reports`, causing the database to fetch and return all records. This could lead to a Denial of Service (DoS) and application memory exhaustion.
🔧 **Fix:** Modified `getLimitWithDefault` in `internal/controllers/financial_controller.go` to strictly bound the `limit` query parameter. Negative limits now fall back to the default value, and maximum limits are securely capped at 1000. Documented the pattern in `.jules/sentinel.md`.
✅ **Verification:** Ran `go test ./internal/controllers/...` and `go test ./internal/routes/...` successfully. Evaluated logic safely bounds integer edge cases.

---
*PR created automatically by Jules for task [2164880030509298106](https://jules.google.com/task/2164880030509298106) started by @styner32*