### PR TITLE
🛡️ Sentinel: [HIGH] Fix GORM pagination limit DoS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 ## 2026-03-13 - [Wildcard CORS + reflect Origin + credentials]
 **Vulnerability:** Treating `ALLOWED_ORIGINS=*` by reflecting the request `Origin` and setting `Access-Control-Allow-Credentials: true` is worse than `*` + credentials (browsers reject the latter). Reflected origin + credentials is accepted, so any site could perform credentialed cross-origin requests.
 **Prevention:** If open CORS is required, use literal `Access-Control-Allow-Origin: *` and omit `Access-Control-Allow-Credentials`. For cookies/auth cross-origin, use an explicit origin allowlist and reflect only listed origins.
+
+## 2026-03-19 - [GORM Pagination Limit DoS Vulnerability]
+**Vulnerability:** The API accepted unvalidated `limit` query parameters. GORM translates negative limits (e.g., `Limit(-1)`) to 'no limit', allowing attackers to bypass pagination and retrieve all records, causing database overload and memory exhaustion (DoS). Extremely large positive numbers also posed a similar memory exhaustion risk.
+**Learning:** In GORM, negative limits do not cause SQL errors; they silently disable the `LIMIT` clause. Any user-facing pagination parameters must be strictly bounded before being passed to ORM queries.
+**Prevention:** Implement a centralized pagination parser that strictly validates limits, ensuring they are strictly positive and capped to a sensible maximum (e.g., `if limit <= 0 { limit = default }` and `if limit > 100 { limit = 100 }`).

--- a/internal/controllers/financial_controller.go
+++ b/internal/controllers/financial_controller.go
@@ -316,5 +316,13 @@ func getLimitWithDefault(c *gin.Context, defaultValue int) int {
 			return defaultValue
 		}
 	}
+
+	if limit <= 0 {
+		return defaultValue
+	}
+	if limit > 100 {
+		return 100
+	}
+
 	return limit
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The API accepted unvalidated `limit` query parameters. In GORM, a negative limit like `Limit(-1)` disables pagination entirely, allowing an attacker to fetch all records in the database simultaneously. Additionally, extremely large positive limits posed a similar threat.
🎯 Impact: This could be exploited to cause Denial of Service (DoS) via severe database overload and memory exhaustion on the application server.
🔧 Fix: Updated `getLimitWithDefault` to strictly enforce bounds on the `limit` parameter. Non-positive numbers fall back to the default value, and any requested limit larger than 100 is clamped to 100. Added documentation in `.jules/sentinel.md` regarding this specific GORM behavior.
✅ Verification: Ran the controllers test suite (`go test ./internal/controllers/...`) to confirm the bounds checking does not introduce any regressions. Verified logic correctly bounds parameters.

---
*PR created automatically by Jules for task [9400671503812693271](https://jules.google.com/task/9400671503812693271) started by @styner32*