### PR TITLE
🛡️ Sentinel: [HIGH] Fix GORM Negative Limit DoS Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 ## 2026-03-13 - [Wildcard CORS + reflect Origin + credentials]
 **Vulnerability:** Treating `ALLOWED_ORIGINS=*` by reflecting the request `Origin` and setting `Access-Control-Allow-Credentials: true` is worse than `*` + credentials (browsers reject the latter). Reflected origin + credentials is accepted, so any site could perform credentialed cross-origin requests.
 **Prevention:** If open CORS is required, use literal `Access-Control-Allow-Origin: *` and omit `Access-Control-Allow-Credentials`. For cookies/auth cross-origin, use an explicit origin allowlist and reflect only listed origins.
+
+## 2024-05-18 - [GORM Negative Limit Pagination DoS]
+**Vulnerability:** GORM interprets `Limit(-1)` and any negative limits as "no limit", fetching the entire database table. User-provided pagination arguments like `?limit=-1` weren't validated, leading to potential memory exhaustion and DoS.
+**Learning:** External inputs mapped directly to ORM methods (like Limit/Offset) can cause severe performance issues or DoS. Always define boundaries.
+**Prevention:** Strictly validate and clamp pagination limits between sensible minimum (> 0) and maximum (e.g., 100) bounds before passing them to GORM.

--- a/internal/controllers/financial_controller.go
+++ b/internal/controllers/financial_controller.go
@@ -316,5 +316,15 @@ func getLimitWithDefault(c *gin.Context, defaultValue int) int {
 			return defaultValue
 		}
 	}
+
+	// Security Fix: Prevent DoS by capping pagination limit.
+	// GORM treats negative limits as 'no limit', causing full table scans.
+	if limit <= 0 {
+		limit = defaultValue
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
 	return limit
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** GORM translates negative limit parameters (e.g., `Limit(-1)`) to 'no limit', fetching the entire database table into memory. The `limit` query parameter was converted to an integer via `strconv.Atoi` but was not validated for positive values.
🎯 **Impact:** An attacker could exploit this by passing `?limit=-1` to multiple endpoints, forcing the database to process full table scans, potentially leading to Memory Exhaustion and Denial of Service (DoS).
🔧 **Fix:** Modified `getLimitWithDefault` to constrain the `limit` strictly between 1 and 100. If `<= 0`, it defaults to the configured default or 10. If `> 100`, it is capped at 100.
✅ **Verification:** All tests passed. The fix limits malicious large or negative pagination constraints safely. Added corresponding learning entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [9576074647731564603](https://jules.google.com/task/9576074647731564603) started by @styner32*