### PR TITLE
🛡️ Sentinel: [HIGH] Fix Pagination Limit DoS Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 ## 2026-03-13 - [Wildcard CORS + reflect Origin + credentials]
 **Vulnerability:** Treating `ALLOWED_ORIGINS=*` by reflecting the request `Origin` and setting `Access-Control-Allow-Credentials: true` is worse than `*` + credentials (browsers reject the latter). Reflected origin + credentials is accepted, so any site could perform credentialed cross-origin requests.
 **Prevention:** If open CORS is required, use literal `Access-Control-Allow-Origin: *` and omit `Access-Control-Allow-Credentials`. For cookies/auth cross-origin, use an explicit origin allowlist and reflect only listed origins.
+
+## 2026-03-21 - [Pagination Limit DoS/OOM Vulnerability]
+**Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
+**Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
+**Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.

--- a/internal/controllers/financial_controller.go
+++ b/internal/controllers/financial_controller.go
@@ -47,6 +47,8 @@ type ReportSummaryResponse struct {
 	RawReport     string          `json:"raw_report"`
 }
 
+const maxPageLimit = 100
+
 // GetCompanies returns a list of all companies
 func (fc *FinancialController) GetCompanies(c *gin.Context) {
 	ctx := c.Request.Context()
@@ -315,6 +317,14 @@ func getLimitWithDefault(c *gin.Context, defaultValue int) int {
 			log.Printf("failed to parse limit: %v, using default value: %d", err, defaultValue)
 			return defaultValue
 		}
+
+		if limit <= 0 {
+			return defaultValue
+		}
+		if limit > maxPageLimit {
+			return maxPageLimit
+		}
 	}
+
 	return limit
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The application dynamically set database pagination limits based on user input, without validating that the limit is greater than zero and reasonably bounded. GORM treats a negative limit parameter as "no limit", allowing an attacker to fetch millions of records into memory at once, leading to application crashes (OOM) or database DoS.
🎯 Impact: Denial of Service (DoS) and potential application crashing due to Out Of Memory (OOM) errors if large datasets exist.
🔧 Fix: Updated the `getLimitWithDefault` function in `internal/controllers/financial_controller.go` to explicitly enforce bounds. Limits are now bounded strictly between 1 and 100.
✅ Verification: Ran `go test ./internal/controllers/...` locally to ensure no breaking changes in tests and confirmed behavior manually. Added learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11489347038970244806](https://jules.google.com/task/11489347038970244806) started by @styner32*