### PR TITLE
🛡️ Sentinel: Add HTTP client timeouts for external API requests

### DIFF
--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,9 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,7 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: External API calls to Binance and FRED were using the default `http.Get()`, which lacks a timeout. This could lead to hanging connections and resource exhaustion (Denial of Service) if the external services are slow or unresponsive.
🎯 Impact: If exploited or if the external APIs fail to respond, the application could consume all available goroutines and file descriptors, leading to an application crash.
🔧 Fix: Replaced `http.Get()` in `internal/pkg/binance/api.go` with a custom `http.Client` featuring a 10-second timeout. Updated `internal/pkg/fred/api.go` to use its existing `c.client`, which already had a timeout configured.
✅ Verification: Ensure the application builds and the tests run successfully. The changes are straightforward and do not affect functionality beyond adding safety mechanisms for the HTTP connections.

---
*PR created automatically by Jules for task [4158532349226163298](https://jules.google.com/task/4158532349226163298) started by @styner32*