### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service (DoS) vulnerability via hanging HTTP connections

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-03-24 - [Denial of Service via Default HTTP Client]
+
+**Vulnerability:** The application used Go's default `http.Get()` for external API calls in packages like `binance` and `fred`. The default `http.Client` has no timeout configured. If an external API becomes unresponsive or hangs indefinitely, the connection will stay open forever, potentially exhausting available file descriptors or goroutines, leading to a Denial of Service (DoS).
+**Learning:** External network calls must never be trusted to return promptly. Always defensively configure network boundaries. Go's default `http.DefaultClient` and convenience methods like `http.Get()` or `http.Post()` are generally unsafe for production use because they lack timeouts by default.
+**Prevention:** Always instantiate a custom `http.Client` with an explicit `Timeout` (e.g., `Timeout: 20 * time.Second`) before making external HTTP requests. Avoid using `http.Get()`, `http.Post()`, etc. from the `net/http` package directly.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,12 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Security: Use custom HTTP client with timeout to prevent DoS/resource exhaustion
+	client := &http.Client{
+		Timeout: 20 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,9 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+
+	// Security: Use custom HTTP client with timeout to prevent DoS/resource exhaustion
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The application was using the default `http.Get` for external network calls (Binance, FRED). Go's default HTTP client does not configure a timeout. If the external API is unresponsive, the connection hangs indefinitely.
🎯 **Impact**: If external APIs hang, all goroutines making those requests will block forever, eventually exhausting available file descriptors and memory, leading to a Denial of Service (DoS) and application crash.
🔧 **Fix**: 
  - Updated `internal/pkg/binance/api.go` to instantiate and use a custom `http.Client` with a 20-second timeout.
  - Updated `internal/pkg/fred/api.go` to use the struct's existing `c.client` (which is already configured with a 20-second timeout in its constructor).
  - Added an entry to the `.jules/sentinel.md` journal documenting this security learning.
✅ **Verification**: 
  - Code review confirms the removal of all `http.Get` instances from the `internal/pkg` directory.
  - Ran `go test ./internal/pkg/...` (temporarily using `go 1.24.3` locally to bypass network restrictions) to ensure the packages still build and pass tests.

---
*PR created automatically by Jules for task [4568689619832126837](https://jules.google.com/task/4568689619832126837) started by @styner32*