### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix default HTTP client timeouts for external APIs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-03-27 - [Default HTTP Client Timeout Resource Exhaustion]
+
+**Vulnerability:** External API calls used standard `http.Get()` in places like `binance` and `fred` API wrappers. Go's default `http.Client` has no configured timeout. If an external service hangs, the connection remains open indefinitely, potentially exhausting server resources (Denial of Service).
+**Learning:** `http.Get` and `http.Post` must never be used in production for external communication, as an uncooperative or slow downstream service can quickly lead to thread/connection pool exhaustion in the application.
+**Prevention:** Always use a custom `http.Client` with an explicit `Timeout` defined (e.g., `Timeout: 10 * time.Second`) for all outgoing HTTP requests.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,13 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Security: Use a custom client with an explicit timeout to prevent hanging
+	// connections and resource exhaustion (Denial of Service).
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,10 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+
+	// Security: Use the configured client with an explicit timeout to prevent
+	// hanging connections and resource exhaustion (Denial of Service).
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** External API wrappers (`binance`, `fred`) were using Go's default `http.Get()`, which has no timeout configured.
🎯 **Impact:** If the external services (`api.binance.com`, `api.stlouisfed.org`) experience latency or become uncooperative, the HTTP connections will hang indefinitely. Over time, this can lead to thread or connection pool exhaustion, causing a Denial of Service (DoS) for the application.
🔧 **Fix:** Replaced `http.Get(url)` with explicit `client.Get(url)` calls. Configured the clients with explicit timeouts (`Timeout: 10 * time.Second` for Binance, and used the existing 20-second configured client for FRED). Added explanatory security comments. Documented this learning in `.jules/sentinel.md`.
✅ **Verification:** Verified that the code compiles, the HTTP clients are now correctly initialized with timeouts, and there are no regressions by building the specific packages.

---
*PR created automatically by Jules for task [3366942891668985351](https://jules.google.com/task/3366942891668985351) started by @styner32*