### PR TITLE
🛡️ Sentinel: [MEDIUM] Add timeout to external API calls

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-19 - [Default HTTP Client Missing Timeout]
+
+**Vulnerability:** External HTTP API calls were made using the default `http.Get` which has no timeout configured. This can lead to hanging connections if the remote server is unresponsive, eventually causing resource exhaustion (e.g. running out of file descriptors or goroutines) leading to a Denial of Service.
+**Learning:** By default, Go's `http.Get` and `http.DefaultClient` do not have any timeout. If external dependencies fail to respond, the connection could hang indefinitely.
+**Prevention:** Always use a custom `http.Client` with an explicit, sensible `Timeout` configured for external API calls, especially those acting on user requests or within critical workflows.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"slices"
+	"time"
 	"strconv"
 	"strings"
 )
@@ -21,7 +22,11 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	client := &http.Client{
+		Timeout: 20 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,7 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: External HTTP API calls were made using the default `http.Get` which has no timeout configured.
🎯 Impact: This can lead to hanging connections if the remote server is unresponsive, eventually causing resource exhaustion (e.g. running out of file descriptors or goroutines) leading to a Denial of Service.
🔧 Fix: Replaced `http.Get` with a custom `http.Client` that has an explicit `Timeout` configured (20 seconds) in Binance and FRED API clients.
✅ Verification: Verified the code builds correctly (`go build`) and `go test` completes successfully.

---
*PR created automatically by Jules for task [11890783899004515523](https://jules.google.com/task/11890783899004515523) started by @styner32*