### PR TITLE
🛡️ Sentinel: [MEDIUM] Add timeouts to external API HTTP clients

### DIFF
--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"slices"
+	"time"
 	"strconv"
 	"strings"
 )
@@ -21,7 +22,12 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Security: Use custom client with timeout instead of default http.Get to prevent hanging connections
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom client with timeout instead of default http.Get to prevent hanging connections
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application was using the default `http.Get` client for external API calls to FRED and Binance. The default HTTP client does not have a timeout configured, which can lead to hanging connections if the remote server becomes unresponsive or drops packets silently.
🎯 Impact: An attacker or a malfunctioning remote server could cause the application to consume excessive resources (goroutines, file descriptors, memory) by holding connections open indefinitely, leading to a Denial of Service (DoS).
🔧 Fix: Replaced `http.Get` calls with custom `http.Client` instances configured with explicit timeouts (10s for Binance, and leveraging the existing 20s client for FRED).
✅ Verification: Ensure `go test ./internal/pkg/...` passes and verify via code review that `http.Get` is no longer used in `internal/pkg/fred/` and `internal/pkg/binance/`.

---
*PR created automatically by Jules for task [6796829292542515973](https://jules.google.com/task/6796829292542515973) started by @styner32*