### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unconfigured HTTP client timeouts causing DoS risk

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-03-31 - [Hanging Connections via Default HTTP Client]
+
+**Vulnerability:** The application used the global `http.Get(url)` and unconfigured HTTP clients when making requests to external APIs (e.g., Binance, FRED). Because the default Go HTTP client has no timeout, network issues or slow external servers can cause connections to hang indefinitely. An attacker or a malfunctioning external service could exploit this to exhaust server resources (goroutines, file descriptors), leading to a Denial of Service (DoS).
+**Learning:** Even when configuring a custom client in a constructor (e.g., `New()`), failing to use it and inadvertently calling `http.Get()` negates the security benefit. It's critical to review the actual request execution.
+**Prevention:** Never use the default `http.Get()`, `http.Post()`, or `http.DefaultClient`. Always construct and use custom `http.Client` instances with explicitly configured `Timeout` values to prevent resource exhaustion vulnerabilities.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,12 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Security: Use custom client with configured timeout to prevent hanging connections (DoS risk)
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom client with configured timeout to prevent hanging connections (DoS risk)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The codebase was using the default `http.Get` for external API requests (Binance, FRED). The default Go HTTP client has NO timeout.
🎯 **Impact:** If the external API hangs or responds extremely slowly, the application would keep the connection open indefinitely. This would leak goroutines and file descriptors, quickly leading to resource exhaustion and a Denial of Service (DoS).
🔧 **Fix:** Replaced the global `http.Get` with custom `http.Client` instances. For Binance, added a client with a 10s timeout. For FRED, correctly utilized the existing custom client instance configured in `New()`.
✅ **Verification:** Verified the code compiles successfully, reviewed the changes, and added a specific learning note in the security journal.

---
*PR created automatically by Jules for task [14999813760865393108](https://jules.google.com/task/14999813760865393108) started by @styner32*