### PR TITLE
🛡️ Sentinel: [MEDIUM] Replace default HTTP clients with timeout-configured clients

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-04-01 - Replace default HTTP clients with timeout-configured clients
+**Vulnerability:** Use of `http.Get` which lacks a configured timeout, leading to potential hanging connections and resource exhaustion (Denial of Service).
+**Learning:** External API clients (e.g., Binance, FRED) must not rely on the default Go HTTP client, which has no timeout by default. A custom `http.Client` with an explicit `Timeout` must be configured. In this repository, `c.client` with timeouts were already used partially (like in Dart client and FRED struct initialization) but `http.Get` was still being called.
+**Prevention:** Always initialize and use an explicit `http.Client{Timeout: ...}` for external HTTP requests instead of package-level `http.Get`, `http.Post`, or `http.DefaultClient`.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,12 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// SECURITY: Use custom client with timeout instead of default http.Get to prevent hanging connections
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// SECURITY: Use custom client with timeout instead of default http.Get to prevent hanging connections
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Use of default `http.Get` which lacks a configured timeout, potentially leading to hanging connections and resource exhaustion (Denial of Service).
🎯 Impact: External API calls to Binance and FRED could hang indefinitely if the respective servers become unresponsive, causing background tasks or API handlers to stall and consume memory/goroutines.
🔧 Fix: Replaced `http.Get` with custom `http.Client` instances configured with 10-second and 20-second timeouts, respectively. Added security comments.
✅ Verification: Ran `go build` and `go test` on the modified packages (`internal/pkg/fred` and `internal/pkg/binance`) to ensure successful compilation and no introduced regressions.

---
*PR created automatically by Jules for task [11158831763867245098](https://jules.google.com/task/11158831763867245098) started by @styner32*