### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix resource exhaustion risk by adding timeouts to external API calls

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-18 - [Missing Timeout for External HTTP Requests]
+**Vulnerability:** The codebase relied on the default `http.Get()` in multiple packages (`binance`, `fred`) for external API calls. The default HTTP client does not have a timeout configured, which can lead to hanging connections and potential resource exhaustion (Denial of Service) if the external API responds slowly or stops responding.
+**Learning:** Default behavior in built-in libraries can introduce subtle security and stability risks, especially when dealing with network I/O.
+**Prevention:** Always instantiate a custom `http.Client` with a strict `Timeout` explicitly configured when communicating with external services.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,12 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Security: Use custom client with timeout instead of default http.Get to prevent hanging connections
+	client := &http.Client{
+		Timeout: 20 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom client with timeout instead of default http.Get to prevent hanging connections
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Use of the default `http.Get()` for external API calls, which has no timeout limit and can cause connections to hang indefinitely.
🎯 **Impact:** If external APIs become slow or unresponsive, this can lead to resource exhaustion and potential Denial of Service (DoS) for the application.
🔧 **Fix:** Replaced default `http.Get` calls with custom `http.Client` instances that have a strict 20-second timeout configured.
✅ **Verification:** Ran `go test ./internal/pkg/...` and `go build ./internal/...` to ensure code compiles and functionality remains intact. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15278545554384335783](https://jules.google.com/task/15278545554384335783) started by @styner32*