### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix default HTTP client timeout vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-03-22 - [Default HTTP Client Timeout Exhaustion]
+
+**Vulnerability:** External API calls to Binance and FRED were using `http.Get()`, which utilizes Go's default `http.Client`. This default client does not have a configured timeout. If the remote server hangs or is slow to respond, the connection can stay open indefinitely, leading to resource exhaustion (goroutine and file descriptor leaks) and potential Denial of Service (DoS).
+**Learning:** Never use the default `http.Client` for production code when interacting with external services, as it implicitly relies on external dependencies operating perfectly.
+**Prevention:** Always instantiate a custom `http.Client` and explicitly set a `Timeout` value (e.g., `Timeout: 20 * time.Second`) before making HTTP requests to external endpoints.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,12 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// 🛡️ Sentinel: Use custom client with timeout instead of default http.Get
+	client := &http.Client{
+		Timeout: 20 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,7 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	resp, err := c.client.Get(url) // 🛡️ Sentinel: Use custom client with timeout instead of default http.Get
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: External API integrations with Binance and FRED were using Go's default `http.Get()`, which lacks a configured timeout. This relies entirely on the remote server's responsiveness.
🎯 Impact: If the remote server hangs or is slow to respond, the connection stays open indefinitely. This can lead to resource exhaustion (leaked goroutines and file descriptors) and cause Denial of Service (DoS).
🔧 Fix: Replaced `http.Get()` with explicitly configured custom `http.Client` instances having 20-second timeouts.
✅ Verification: Ran `go build` to verify compilation for `internal/pkg/binance/...` and `internal/pkg/fred/...`.

---
*PR created automatically by Jules for task [11994818240521014800](https://jules.google.com/task/11994818240521014800) started by @styner32*