### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing HTTP timeouts leading to resource exhaustion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-04-05 - [Unbounded HTTP Requests Causing Resource Exhaustion]
+
+**Vulnerability:** External HTTP requests were made using `http.Get()` which relies on the `http.DefaultClient` with no configured timeouts. If the external server hangs, these connections wait indefinitely, exhausting file descriptors, goroutines, and memory.
+**Learning:** `http.DefaultClient` should never be used for external API calls in a production environment as it provides no protection against hanging connections, leading to potential Denial of Service (DoS).
+**Prevention:** Always use a custom `http.Client` with an explicit `Timeout` configured for any external API calls.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,11 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,7 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix missing HTTP timeouts leading to resource exhaustion

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unbounded HTTP requests were being made using `http.Get()`, which uses `http.DefaultClient` by default with no configured timeout.
🎯 **Impact:** If external APIs (Binance/FRED) hang without explicitly closing connections, the un-timed requests will wait indefinitely. This leads to resource exhaustion (exhausted goroutines, open file descriptors, and memory) creating a Denial of Service (DoS) vulnerability.
🔧 **Fix:** 
1. Replaced `http.Get()` in `internal/pkg/binance/api.go` with a custom `http.Client` having a 10-second timeout.
2. Updated `internal/pkg/fred/api.go` to use the pre-configured `c.client` (with a 20-second timeout) rather than bypassing it with `http.Get()`.
3. Documented the learning in `.jules/sentinel.md` as required.
✅ **Verification:** Verified by compiling the affected packages and reading code files to ensure timeouts are adequately handled.

---
*PR created automatically by Jules for task [5951412361309939819](https://jules.google.com/task/5951412361309939819) started by @styner32*