### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeouts on external API calls

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-03-24 - [Default http.Get Missing Timeouts (DoS)]
+
+**Vulnerability:** External APIs were called using the default `http.Get(url)`, which does not have any timeout configured. An attacker or a malfunctioning external API could cause the connection to hang indefinitely, tying up goroutines, memory, and file descriptors.
+**Learning:** Go's `http.Get`, `http.Post`, and default `http.Client` lack a default timeout. In a high-throughput or public-facing service, a slow or unresponsive external dependency can rapidly exhaust server resources and cause a Denial of Service (DoS).
+**Prevention:** Never use default `http.Get` or unconfigured `http.Client`. Always create a custom `http.Client` and explicitly configure its `Timeout` property when making HTTP requests.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,10 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// SECURITY: Use custom client with timeout to prevent resource exhaustion from hanging connections
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// SECURITY: Use custom client with timeout to prevent hanging connections (DoS vulnerability)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** External APIs (FRED and Binance) were called using Go's default `http.Get()`, which does not configure any timeout.
🎯 **Impact:** If an external API server is unresponsive or an attacker maliciously keeps the connection open, it can lead to indefinitely hanging connections. This exhausts goroutines, file descriptors, and memory, ultimately causing a Denial of Service (DoS) for the application.
🔧 **Fix:** 
- In `fred/api.go`, changed `http.Get(url)` to use the pre-configured `c.client.Get(url)` which has a 20s timeout.
- In `binance/api.go`, instantiated a custom `http.Client` with a 10s timeout instead of relying on the default client.
- Added corresponding security documentation to Sentinel's journal.
✅ **Verification:** Verified fixes through compilation (`go build`) and ran available test suites.

---
*PR created automatically by Jules for task [15353032257997728875](https://jules.google.com/task/15353032257997728875) started by @styner32*