### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix resource exhaustion vulnerability in external API calls

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-04-10 - [Resource Exhaustion Vulnerability via External HTTP Calls]
+
+**Vulnerability:** The application used the default `http.Get` for external API requests (e.g., Binance, FRED). The default `http.DefaultClient` has no timeout configuration, meaning it will block indefinitely if the external server is slow or unresponsive. An attacker could potentially abuse endpoints that trigger these external calls to exhaust server connections and memory, leading to a Denial of Service (DoS).
+**Learning:** Standard library HTTP clients in Go (and many other languages) often prioritize simplicity over safety. When dealing with external dependencies, always assume they can fail or hang.
+**Prevention:** Never use the default `http.Get` or an unconfigured `http.Client`. Always instantiate custom HTTP clients with explicit, reasonable timeouts (e.g., `&http.Client{Timeout: 10 * time.Second}`).

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,12 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Security: Using custom configured http.Client with timeout to prevent resource exhaustion
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Using custom configured http.Client with timeout to prevent resource exhaustion
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application used the default `http.Get` which has no timeout. This can cause the application to hang indefinitely if the external service (Binance or FRED) is unresponsive.
🎯 Impact: Attackers could potentially trigger these endpoints to exhaust application resources (connections, memory), leading to a Denial of Service (DoS).
🔧 Fix: Replaced `http.Get` with explicitly configured `http.Client` instances that include strict timeouts (e.g., 10 seconds). For `fred`, the pre-existing configured `client` was used. Added security comments.
✅ Verification: Compiled successfully (`go build`) and formatted. Recorded the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [13930634192074386751](https://jules.google.com/task/13930634192074386751) started by @styner32*