### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing HTTP timeouts causing resource exhaustion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-04-11 - [Missing HTTP Timeouts]
+
+**Vulnerability:** External API calls used the default `http.Get()`, which lacks a timeout. This exposes the application to resource exhaustion and potential Denial of Service (DoS) if the external server hangs or is slow to respond. In one case, a custom client was initialized but `http.Get` was called directly instead.
+**Learning:** Even if a secure client is defined, it must be explicitly invoked. Relying on default package-level HTTP functions bypasses any application-level security configurations.
+**Prevention:** Always use a custom `http.Client` with an explicit `Timeout` set, and ensure external API requests are made via `client.Get()` or `client.Do()` instead of the global `http.Get()` or `http.Post()`.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,11 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// SECURITY: Use a custom http.Client with a timeout instead of http.Get
+	// to prevent resource exhaustion/DoS if the Binance API hangs.
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,10 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+
+	// SECURITY: Use c.client.Get instead of http.Get to enforce the configured timeout
+	// and prevent resource exhaustion if the API hangs.
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
Added explicit timeouts to HTTP clients in the Binance and FRED API integrations to mitigate the risk of resource exhaustion and Denial of Service (DoS) caused by hanging external connections. Replaced usage of the default `http.Get()` with configured `http.Client` instances. Also updated Sentinel Journal with learnings.

---
*PR created automatically by Jules for task [8641463836797814327](https://jules.google.com/task/8641463836797814327) started by @styner32*