### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unbounded HTTP client resource exhaustion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-04-12 - [Unbounded HTTP Client Resource Exhaustion]
+
+**Vulnerability:** External API calls in `internal/pkg/binance` and `internal/pkg/fred` were using the package-level `http.Get()`. This default client does not enforce any timeouts for HTTP requests. If the external API hangs or responds very slowly, the application's goroutines will block indefinitely, leading to resource exhaustion (Denial of Service).
+**Learning:** Default HTTP clients in Go (such as `http.Get`, `http.Post`, and `http.DefaultClient`) lack timeout configurations by default, making them unsafe for production use when calling untrusted or third-party external networks.
+**Prevention:** Always use a custom `http.Client` with an explicit `Timeout` property configured. Avoid using `http.Get` and `http.Post` and instead instantiate and explicitly call methods on the custom client (e.g., `client.Get()`).

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,10 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// SECURITY: Use custom client with timeout to prevent resource exhaustion/DoS
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,9 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// SECURITY: Use existing initialized custom client with timeout instead of global http.Get
+	// to prevent resource exhaustion/DoS if the external API hangs
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unbounded HTTP requests (CWE-400: Uncontrolled Resource Consumption). The application used Go's default `http.Get()`, which does not enforce any timeouts, to fetch data from external APIs.
🎯 **Impact:** If the external API hangs or responds extremely slowly, the goroutine making the request blocks indefinitely. This can lead to resource exhaustion (goroutine leaks) and eventually Denial of Service (DoS) for the application.
🔧 **Fix:** Replaced the global `http.Get()` calls with custom `http.Client` instances configured with strict `Timeout` properties (e.g., 10 seconds). In `internal/pkg/fred/api.go`, the already configured client (`c.client`) was utilized. In `internal/pkg/binance/api.go`, a new client with a 10-second timeout was instantiated.
✅ **Verification:**
1. Code review verified the fix uses `client.Get()` instead of `http.Get()`.
2. Packages compile and build successfully.

---
*PR created automatically by Jules for task [4074869457637763171](https://jules.google.com/task/4074869457637763171) started by @styner32*