### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix resource exhaustion in FRED API client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-04-13 - [Missing HTTP Timeout Risk (DoS)]
+
+**Vulnerability:** The application used the default `http.Get()` which lacks a timeout. If an external API hangs indefinitely, this could cause resource exhaustion and potentially Denial of Service (DoS) by keeping connections and goroutines open.
+**Learning:** Default `http` package functions like `http.Get()` and `http.Post()` do not enforce timeouts by default, making them unsafe for production use when calling external services.
+**Prevention:** Always use a custom `http.Client` with an explicit `Timeout` configured when making external requests.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,9 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+
+	// SECURITY: Use custom client with timeout to prevent resource exhaustion (DoS) from hanging external API
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application used the default `http.Get()` which lacks a timeout.
🎯 Impact: If the external FRED API hangs indefinitely, it could cause resource exhaustion and potentially Denial of Service (DoS) by keeping connections and goroutines open.
🔧 Fix: Replaced `http.Get(url)` with `c.client.Get(url)`, which utilizes the already configured custom HTTP client with a 20-second timeout.
✅ Verification: Code compiles successfully (`go build ./internal/pkg/fred/...`) and tests pass.

---
*PR created automatically by Jules for task [318436266772811889](https://jules.google.com/task/318436266772811889) started by @styner32*