### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Resource Exhaustion (Missing HTTP Timeouts)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-24 - [Missing HTTP Timeouts Leading to Resource Exhaustion]
+
+**Vulnerability:** The application used the default package-level `http.Get` method for making external API calls (e.g., to Binance and FRED APIs). The default Go HTTP client does not have a timeout configured. If an external API hangs or responds extremely slowly, it can tie up application resources (goroutines, memory, file descriptors), potentially leading to a Denial of Service (DoS) or Out-Of-Memory (OOM) error.
+**Learning:** Default libraries often prioritize convenience over security defaults. In Go, relying on `http.Get` or `http.Post` without configuring a custom client is a critical risk in production environments because it lacks boundaries on how long the application will wait for a response.
+**Prevention:** Always instantiate a custom `http.Client` with an explicit `Timeout` set (e.g., `&http.Client{Timeout: 10 * time.Second}`) when making external network requests.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,12 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Security: Use custom client with strict timeout to prevent resource exhaustion (DoS)
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use configured client with timeout to prevent resource exhaustion (DoS)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The application used Go's default `http.Get` for external API calls. The default client has NO timeout.
🎯 **Impact:** If external APIs (Binance, FRED) hang or respond extremely slowly, application resources (goroutines, file descriptors, memory) will be tied up indefinitely, leading to Resource Exhaustion and Denial of Service (DoS) or Out-Of-Memory (OOM) errors.
🔧 **Fix:** 
- In `internal/pkg/binance/api.go`, instantiated a custom `http.Client` with a strict 10-second timeout.
- In `internal/pkg/fred/api.go`, utilized the existing configured client (`c.client`) which has a 20-second timeout instead of falling back to the default `http.Get`.
- Documented findings in `.jules/sentinel.md`.
✅ **Verification:** Verified via `go build` and `go test` that both packages compile and run properly without regressions.

---
*PR created automatically by Jules for task [2265581163846704738](https://jules.google.com/task/2265581163846704738) started by @styner32*