### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability in external API call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-04-16 - [Missing HTTP Client Timeout]
+
+**Vulnerability:** A package (`fred`) correctly initialized a custom `http.Client` with a 20-second timeout but failed to use it for an external API call, reverting to the default `http.Get()`. The default client has no timeout, leading to potential resource exhaustion (DoS) if the external service hangs.
+**Learning:** Initializing a secure client is not enough; we must ensure it is actually invoked. In complex codebases, the default `http.Get()` or `http.Post()` might be mistakenly used instead of the custom client struct field.
+**Prevention:** Avoid `http.Get()` or `http.Post()` throughout the codebase. Always use the structured client's method (`c.client.Get()`) or construct an explicit `http.Client` with timeouts where one isn't passed down.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom client with configured timeout instead of http.Get to prevent DoS via resource exhaustion
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability in external API call

🚨 Severity: MEDIUM
💡 Vulnerability: The `FREDClient.GetHighYieldSpread` method used the default `http.Get()` which has no timeout configured.
🎯 Impact: If the external FRED API hangs or delays responses indefinitely, the calling goroutines will block forever, leading to resource exhaustion (Denial of Service) and Out of Memory (OOM) errors.
🔧 Fix: Replaced `http.Get()` with `c.client.Get()`, leveraging the explicitly initialized `http.Client` which is configured with a 20-second timeout.
✅ Verification: Compiled the `internal/pkg/fred` package successfully and verified tests. Added journal entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [12217590554455640774](https://jules.google.com/task/12217590554455640774) started by @styner32*