### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix default HTTP client missing timeout in Binance API

### DIFF
--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,12 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Use custom client with timeout to prevent DoS via resource exhaustion
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `GetCryptoRSI` function in `internal/pkg/binance/api.go` used the default `http.Get` function to fetch data from the Binance API. The default HTTP client in Go does not have a timeout configured.
🎯 Impact: If the external Binance API server hangs, is slow to respond, or maliciously keeps the connection open without sending data, the Go application will block indefinitely waiting for the response. An attacker could potentially exhaust all available resources (file descriptors, memory, goroutines) by triggering this endpoint multiple times, leading to a Denial of Service (DoS).
🔧 Fix: Replaced `http.Get(url)` with a custom `http.Client` that explicitly configures a 10-second timeout (`Timeout: 10 * time.Second`).
✅ Verification: The codebase compiled successfully with `go build ./internal/pkg/binance/...`. Any network requests taking longer than 10 seconds will now correctly return a timeout error instead of hanging indefinitely.

---
*PR created automatically by Jules for task [5568271696347650023](https://jules.google.com/task/5568271696347650023) started by @styner32*