### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing timeout DoS vulnerability in FREDClient

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-04-18 - [Default http.Get Missing Timeout DoS Vulnerability]
+
+**Vulnerability:** The `internal/pkg/fred/api.go` package used the default `http.Get(url)` to fetch data, which has no default timeout. If the external API hangs or responds extremely slowly, the application thread can be blocked indefinitely, leading to resource exhaustion and Denial of Service (DoS).
+**Learning:** Even when a struct is initialized with a custom `http.Client` that has a proper `Timeout` configured, developers may mistakenly use package-level functions like `http.Get` instead of invoking `client.Get`. Go's default `http.DefaultClient` has no timeout.
+**Prevention:** Always ensure that network requests to external services use a specifically configured `http.Client` with explicit timeouts. Verify that the configured client is the one actually being used to execute the request (e.g., `c.client.Get(url)`).

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom client with timeout instead of default http.Get to prevent DoS via resource exhaustion
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `FREDClient.GetHighYieldSpread` method used the default `http.Get(url)` to fetch data. The default Go HTTP client has no timeout.
🎯 Impact: If the St. Louis Fed API hangs or responds extremely slowly, the calling goroutine would be blocked indefinitely. Under load, this could exhaust application resources and cause a Denial of Service (DoS).
🔧 Fix: Replaced `http.Get(url)` with the locally configured `c.client.Get(url)`, which has a 20-second timeout explicitly defined in the `New` constructor. Added a security comment.
✅ Verification: Compiled successfully (`go build ./internal/pkg/fred/...`) and reviewed custom client usage. Documented the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [4921963469411392254](https://jules.google.com/task/4921963469411392254) started by @styner32*