### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing HTTP timeout in Binance API client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+## 2026-04-19 - [Missing HTTP Client Timeout]
+**Vulnerability:** Go's default `http.Get` uses the default HTTP client which lacks a timeout. If the external server hangs, the goroutine calling it blocks indefinitely, potentially leading to resource exhaustion (DoS).
+**Learning:** External API calls should never be made with an unbounded timeout. The default Go `http.Get` is dangerous for production systems.
+**Prevention:** Always create a custom `http.Client` with an explicit `Timeout` configured and use it for outbound requests.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,12 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Security: Use a custom HTTP client with a strict timeout to prevent resource exhaustion (DoS)
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The Binance API integration (`internal/pkg/binance/api.go`) used the default Go `http.Get()` function. This function uses the `DefaultClient` which has no timeout configured. If the Binance API hangs or is slow to respond, the calling goroutine will block indefinitely. In a highly concurrent environment, this can lead to resource exhaustion and a Denial of Service (DoS).
🎯 **Impact:** Potential resource exhaustion, application lockups, and Denial of Service (DoS).
🔧 **Fix:** Replaced `http.Get(url)` with a custom `http.Client` that explicitly configures a 10-second `Timeout`. Added a security comment explaining the reason for the custom client.
✅ **Verification:** Verified by compiling the package (`go build ./internal/pkg/binance/...`).
📚 **Journal:** Added an entry to `.jules/sentinel.md` noting the danger of using Go's default `http.Get` for external API calls.

---
*PR created automatically by Jules for task [1268682466486552438](https://jules.google.com/task/1268682466486552438) started by @styner32*