### PR TITLE
🛡️ Sentinel: [HIGH] Fix default HTTP client DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2025-02-28 - [Default HTTP Client DoS]
+**Vulnerability:** Default http.Get lacks a timeout, causing potential DoS.
+**Learning:** Always use a custom HTTP client with an explicit timeout.
+**Prevention:** Use a pre-configured HTTP client with a defined timeout for external requests.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,12 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Security: Use custom client with timeout to prevent DoS via resource exhaustion
+	client := &http.Client{
+		Timeout: 20 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom client with timeout to prevent DoS via resource exhaustion
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application used the default `http.Get` for fetching external API data (Binance, FRED). The default `http.Client` lacks a timeout, meaning if the external API hangs or responds extremely slowly, the connection remains open indefinitely. This can lead to connection pool exhaustion, memory leaks, and ultimately a Denial of Service (DoS).
🎯 **Impact:** If an attacker can trigger repeated external API calls or if the external service experiences issues, the application could consume all available resources, causing it to crash or become unresponsive to legitimate users.
🔧 **Fix:** 
- In `internal/pkg/fred/api.go`, replaced the direct use of `http.Get` with `c.client.Get(url)`, leveraging the pre-configured HTTP client which has a 20-second timeout.
- In `internal/pkg/binance/api.go`, instantiated a custom `http.Client` with an explicit 20-second timeout and used it instead of the global `http.Get`.
✅ **Verification:** 
- Code review confirms the absence of `http.Get` without timeouts in modified packages.
- Tests passed (`go test ./internal/pkg/...`).

---
*PR created automatically by Jules for task [11667297860606166618](https://jules.google.com/task/11667297860606166618) started by @styner32*