### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeouts on external API calls

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-03-22 - [Missing Timeouts on External API Calls]
+
+**Vulnerability:** The application used the default `http.Get` for external API calls. The default HTTP client in Go does not have a timeout configured, which can lead to hanging connections and potential resource exhaustion (Denial of Service) if the external API becomes unresponsive.
+**Learning:** Default HTTP clients lack sensible defaults for timeouts, which is a common security pitfall in Go applications interacting with third-party services.
+**Prevention:** Always initialize and use a custom `http.Client` with an explicit `Timeout` configured for any external network communication to ensure the application fails fast and securely when dependencies are unavailable.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,12 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Security: Use custom client with explicit Timeout to prevent resource exhaustion (DoS) if external API hangs
+	client := &http.Client{
+		Timeout: 20 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom client with explicit Timeout to prevent resource exhaustion (DoS) if external API hangs
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
* 🚨 Severity: MEDIUM
* 💡 Vulnerability: Missing timeouts on external API calls using default `http.Get`.
* 🎯 Impact: Resource exhaustion (DoS) and application hang if external APIs become unresponsive.
* 🔧 Fix: Implemented custom `http.Client` objects with explicit 20-second timeouts.
* ✅ Verification: Verified compilation with `go build ./internal/pkg/...` and verified no regressions by passing tests with `go test ./internal/pkg/...`.

---
*PR created automatically by Jules for task [17677385358339765805](https://jules.google.com/task/17677385358339765805) started by @styner32*