### PR TITLE
🛡️ Sentinel: Add HTTP client timeouts to prevent resource exhaustion

### DIFF
--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Sentinel: Explicitly use custom HTTP client with timeout to prevent resource exhaustion (DoS)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing timeout on external API call in FRED client (using default `http.Get`).
🎯 Impact: Potential resource exhaustion and Denial of Service (DoS) if the external API hangs.
🔧 Fix: Explicitly invoke the custom `http.Client` with a configured timeout.
✅ Verification: Ensured code compiles and tests pass.

---
*PR created automatically by Jules for task [13980137868050355815](https://jules.google.com/task/13980137868050355815) started by @styner32*