### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix resource exhaustion vulnerability in Binance API client

### DIFF
--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,13 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Use a custom client with an explicit timeout to prevent resource exhaustion (DoS)
+	// if the external API hangs, avoiding the use of the default http.Get.
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `GetCryptoRSI` function in `internal/pkg/binance/api.go` used the default `http.Get` which lacks a configured timeout. If the external Binance API hangs or becomes unresponsive indefinitely, it could exhaust system resources (e.g., holding file descriptors open), leading to a Denial of Service (DoS).
🎯 **Impact:** Potential application crash or unresponsiveness due to exhausted network connections.
🔧 **Fix:** Replaced the default `http.Get` with a custom `http.Client` initialized with an explicit 10-second timeout.
✅ **Verification:**
1. Ran `go build ./internal/pkg/binance/...` to confirm no compilation issues.
2. Ran `go test ./internal/pkg/binance/...` to ensure there are no regressions.

---
*PR created automatically by Jules for task [13018703282666932296](https://jules.google.com/task/13018703282666932296) started by @styner32*