### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Resource Exhaustion Vulnerability in External API Call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+## 2025-05-01 - Missing HTTP Client Timeout Default Usage
+**Vulnerability:** The default `http.Get` was used, which has no timeout configured, leading to potential resource exhaustion (DoS) vulnerabilities if external APIs hang.
+**Learning:** External API integrations frequently bypass securely initialized clients.
+**Prevention:** Always use a custom `http.Client` with explicit timeouts when making HTTP requests, and ensure these customized clients are actually invoked (e.g., `client.Get()`).

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// SEC: Using custom client with Timeout to prevent resource exhaustion (DoS)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Default `http.Get` lacks a timeout, making the application vulnerable to resource exhaustion (DoS) attacks if the FRED API hangs.
🎯 Impact: An attacker or a hanging external API could cause connections to remain open indefinitely, consuming file descriptors and memory until the service crashes.
🔧 Fix: Switched to using the already-initialized custom `http.Client` that has a strict 20-second timeout.
✅ Verification: Ensured code compiles and external HTTP requests use the custom timeout configuration.

---
*PR created automatically by Jules for task [13754737343578067726](https://jules.google.com/task/13754737343578067726) started by @styner32*