### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerability by replacing default http.Get with custom client

### DIFF
--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,10 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+
+	// Security: Use custom client with timeout instead of default http.Get
+	// to prevent resource exhaustion (DoS) if the external API hangs.
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
* 🚨 Severity: CRITICAL
* 💡 Vulnerability: Unbounded package-level `http.Get` lacks a timeout, causing potential resource exhaustion.
* 🎯 Impact: Can lead to Denial of Service (DoS) if the external API hangs.
* 🔧 Fix: Replaced `http.Get` with `c.client.Get` which has a configured timeout.
* ✅ Verification: Verified compilation via `go build ./internal/pkg/fred/...` and ran `go test ./internal/pkg/...`.

---
*PR created automatically by Jules for task [17963538870125257829](https://jules.google.com/task/17963538870125257829) started by @styner32*