### PR TITLE
⚡️ Sentinel: [CRITICAL] Fix HTTP client resource exhaustion vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-24 - [Default HTTP Client Timeout Exhaustion]
+
+**Vulnerability:** The application used the default package-level `http.Get` in `internal/pkg/binance/api.go` which lacks an explicit timeout. If the external Binance API hangs or is slow to respond, this could lead to the exhaustion of server resources by leaving connections and goroutines open indefinitely, resulting in a Denial of Service (DoS) vulnerability.
+**Learning:** Default HTTP clients in Go (`http.Get`, `http.Post`, default `http.Client`) do not have a configured timeout. This means they will wait indefinitely for a response, which is a significant security risk for backend services calling external APIs.
+**Prevention:** Always instantiate a custom `http.Client` and configure an explicit `Timeout` property when making HTTP requests to external services to ensure connections are appropriately terminated and resources are freed.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,12 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Sentinel: Use custom http.Client with timeout to prevent resource exhaustion / DoS
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err


### PR DESCRIPTION
* 🚨 Severity: CRITICAL
* 💡 Vulnerability: Use of default `http.Get` without timeout
* 🎯 Impact: Potential resource exhaustion / Denial of Service (DoS) if the external API hangs
* 🔧 Fix: Implemented a custom `http.Client` with an explicit timeout
* ✅ Verification: Ran `go build` and `go test` for the affected package

---
*PR created automatically by Jules for task [7078905676641632993](https://jules.google.com/task/7078905676641632993) started by @styner32*