### PR TITLE
🛡️ Sentinel: [HIGH] Fix resource exhaustion vulnerability in FRED API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-18 - [Resource Exhaustion (DoS) via Unconfigured http.Client]
+
+**Vulnerability:** The `internal/pkg/fred/api.go` integration used the default package-level `http.Get`, which lacks a configured timeout.
+**Learning:** Using default `http` methods (`http.Get`, `http.Post`) without explicit timeouts can lead to application hangs and resource exhaustion if the external API becomes unresponsive, leaving connections open indefinitely.
+**Prevention:** Always utilize a custom `http.Client` with an explicit `Timeout` configured for external API calls, and avoid using the default package-level HTTP methods.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use configured client instead of default http.Get to prevent DoS via resource exhaustion
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Default `http.Get` lacks a timeout configuration, exposing the application to resource exhaustion if the external API hangs.
🎯 Impact: Potential Denial of Service (DoS) via exhausted network connections or memory.
🔧 Fix: Replaced `http.Get` with the custom client (`c.client.Get`) which has a 20-second timeout configured in the client's constructor. Added a critical learning journal entry to `.jules/sentinel.md`.
✅ Verification: Verified the code compiles correctly and is free of errors.

---
*PR created automatically by Jules for task [13999481062940728821](https://jules.google.com/task/13999481062940728821) started by @styner32*