### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix HTTP client timeout vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-04-30 - [Default HTTP Client Missing Timeout]
+
+**Vulnerability:** The application used the global `http.Get(url)` function to make external API calls. The default HTTP client lacks a timeout, meaning if the external server hangs, the connection remains open indefinitely. This can lead to resource exhaustion (Denial of Service) by consuming all available file descriptors and memory.
+**Learning:** Using the default `http.Client` is dangerous in production code. It exposes the application to external dependency failures cascading into a full application crash.
+**Prevention:** Always instantiate a custom `http.Client` with an explicit `Timeout` (e.g., `Timeout: 20 * time.Second`) before making network requests.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,11 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	client := &http.Client{
+		Timeout: 20 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,7 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Usage of the default `http.Get` which lacks timeouts, leading to potential resource exhaustion (DoS).
🎯 Impact: If the external APIs hang, the application could consume unbounded memory and file descriptors.
🔧 Fix: Replaced `http.Get` with custom HTTP clients configured with explicit 20-second timeouts.
✅ Verification: Verified via compilation and code review.

---
*PR created automatically by Jules for task [10275218507583470268](https://jules.google.com/task/10275218507583470268) started by @styner32*