### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP client timeouts for external APIs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-20 - [Default HTTP Client Resource Exhaustion]
+
+**Vulnerability:** The application used the default `http.Get` for external API requests. The default HTTP client in Go has no timeout configured, which can lead to resource exhaustion (DoS) if the external API hangs or responds slowly.
+**Learning:** Always use a custom `http.Client` with an explicit `Timeout` set, even for simple requests, to ensure the application fails securely and does not consume excessive memory or goroutines when external services degrade.
+**Prevention:** Avoid using package-level `http.Get` or `http.Post`. Instead, initialize an `http.Client` with a sensible timeout (e.g., 10 seconds) and use its `.Get` or `.Post` methods.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,9 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+	// Security: Use a custom HTTP client with an explicit timeout to prevent resource exhaustion (DoS)
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use the configured custom client instead of package-level http.Get to enforce timeouts
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
This pull request fixes a vulnerability where default `http.Get` was used without timeouts.

🚨 Severity: MEDIUM
💡 Vulnerability: Used default `http.Get` which has no timeout, leading to potential resource exhaustion (DoS) if upstream API hangs.
🎯 Impact: Application could consume excessive memory and goroutines, crashing the process.
🔧 Fix: Replaced `http.Get` with custom `http.Client` explicitly setting `Timeout` to 10 seconds in `internal/pkg/binance` and `internal/pkg/fred`.
✅ Verification: Tested compilation locally.

---
*PR created automatically by Jules for task [4817353196303717194](https://jules.google.com/task/4817353196303717194) started by @styner32*