### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeouts in HTTP requests

### DIFF
--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,7 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Default `http.Get` usage without timeouts could lead to resource exhaustion (DoS) if external APIs hang.
🎯 Impact: Attacker or network latency could tie up application goroutines indefinitely, leading to memory exhaustion or service unavailability.
🔧 Fix: Replaced `http.Get` with `c.client.Get` inside `FREDClient.GetHighYieldSpread`, effectively utilizing the existing 20-second timeout configured in `New`.
✅ Verification: Run `go build ./internal/pkg/fred/...` to verify successful compilation.

---
*PR created automatically by Jules for task [11835962726411577095](https://jules.google.com/task/11835962726411577095) started by @styner32*