### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing HTTP timeouts causing DoS risk

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-19 - [Default HTTP Client DoS Risk]
+
+**Vulnerability:** The application used the default `http.Get` method for external API calls (e.g., Binance, FRED). The default Go HTTP client has no timeout configured. A slow or hanging external API response can cause goroutines to hang indefinitely, leading to resource exhaustion (Denial of Service).
+**Learning:** Even when a custom `http.Client` is defined in a struct, it is easy to accidentally fall back to `http.Get`. Standalone functions also often omit custom clients for brevity, introducing hidden DoS risks.
+**Prevention:** Always use a custom `http.Client` with an explicit `Timeout` set. Consider explicitly invoking the custom client (e.g., `client.Get()`) or passing `context.WithTimeout` to request methods.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,11 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,7 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The application used Go's default `http.Get` method for external API calls (e.g., Binance, FRED). The default Go HTTP client has no timeout configured. 
🎯 **Impact:** A slow or hanging external API response can cause goroutines to hang indefinitely, eventually leading to resource exhaustion (Denial of Service/DoS).
🔧 **Fix:** 
- In `internal/pkg/binance/api.go`: Instantiated a custom `http.Client` with a 10-second timeout.
- In `internal/pkg/fred/api.go`: Updated the `GetHighYieldSpread` method to use the struct's existing custom client (`c.client.Get(url)`), which already has a 20-second timeout configured.
- Added a journal entry to `.jules/sentinel.md` documenting the DoS risk associated with `http.Get`.
✅ **Verification:**
- Ran `go test ./internal/pkg/...` to ensure all tests pass.
- Compiled the packages successfully.

---
*PR created automatically by Jules for task [11527490100494691119](https://jules.google.com/task/11527490100494691119) started by @styner32*