### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing HTTP timeouts in external API calls

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-05-04 - [Missing HTTP Client Timeouts]
+
+**Vulnerability:** External API integrations used the package-level `http.Get`, which lacks a default timeout. If the external API hangs, it can lead to goroutine leaks and resource exhaustion (DoS).
+**Learning:** Even when a custom `http.Client` with a timeout is instantiated in a struct constructor (e.g., in the FRED API client), developers may accidentally fallback to using the familiar `http.Get` method in the actual request logic, bypassing the protection.
+**Prevention:** Always explicitly invoke methods on the configured custom `http.Client` (e.g., `c.client.Get()`). Consider linting rules to ban `net/http` package-level `Get`/`Post` functions in favor of custom clients.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,10 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+
+	// SECURITY: Use custom client with timeout instead of package-level http.Get
+	// Default http.Get lacks a timeout and can lead to resource exhaustion (DoS)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `GetHighYieldSpread` function in the FRED API client used the package-level `http.Get()`, which does not have a default timeout, leaving the application vulnerable to goroutine leaks and resource exhaustion (DoS) if the external API hangs.
🎯 **Impact:** If the FRED API server becomes unresponsive, all requests to this endpoint could hang indefinitely, potentially exhausting server resources and bringing down the application.
🔧 **Fix:** Changed `http.Get(url)` to use the custom configured `c.client.Get(url)`, which has a 20-second timeout.
✅ **Verification:** Verify that `go test ./internal/pkg/fred/...` passes and the code builds successfully using `go build ./internal/pkg/fred/...`.

---
*PR created automatically by Jules for task [6059031870684316624](https://jules.google.com/task/6059031870684316624) started by @styner32*