### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unbounded HTTP client timeout DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-05-05 - [Unbounded HTTP Client Timeout DoS]
+
+**Vulnerability:** External API requests in `binance` and `fred` packages used the default `http.Get()`, which lacks a timeout. If the remote server hangs or is slow, the connection remains open indefinitely.
+**Learning:** Using the default package-level `http.Get` or `http.Post` in Go can easily lead to resource exhaustion (Denial of Service) because there are no default timeouts.
+**Prevention:** Always use a custom `http.Client` with an explicit `Timeout` configured for external API calls, and avoid using the default `http.Get` or `http.Post`.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,12 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Security: Use custom client with explicit timeout to prevent DoS via resource exhaustion
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,9 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+
+	// Security: Use configured client with timeout to prevent DoS via resource exhaustion
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: External API calls in `internal/pkg/binance` and `internal/pkg/fred` used the default `http.Get()`, which has no timeout.
🎯 Impact: If external APIs (Binance or FRED) hang or become unresponsive, goroutines and file descriptors will leak, eventually leading to application resource exhaustion and Denial of Service (DoS).
🔧 Fix: Replaced `http.Get()` with custom `http.Client` instances configured with explicit timeouts (10s for Binance, 20s for FRED).
✅ Verification: Run `go build` for both packages to ensure successful compilation.

---
*PR created automatically by Jules for task [154570954673064670](https://jules.google.com/task/154570954673064670) started by @styner32*