### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeout configuration in FRED client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+## 2024-05-24 - Unused Custom HTTP Client
+**Vulnerability:** External API calls using default package-level `http.Get` instead of configured custom clients with timeouts, leading to potential resource exhaustion (DoS) if the external API hangs.
+**Learning:** Even when a custom `http.Client` with a timeout is instantiated (e.g., in `New()` constructors), developers may accidentally fallback to `http.Get()`.
+**Prevention:** Always verify that `client.Get()` is explicitly invoked instead of `http.Get()`. Use linters to ban `http.Get` and `http.Post` in the codebase.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Sentinel: Use configured c.client to enforce timeouts instead of default http.Get
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: External API calls using default package-level `http.Get` instead of configured custom clients with timeouts, leading to potential resource exhaustion (DoS) if the external API hangs.
🎯 Impact: An attacker or a malfunctioning external service could cause the application to hang indefinitely, tying up resources and eventually causing a Denial of Service (DoS) state.
🔧 Fix: Replaced `http.Get(url)` with `c.client.Get(url)` in `GetHighYieldSpread()` to enforce the custom 20s timeout configured in the `New` constructor.
✅ Verification: Tested compilation with `go build ./internal/pkg/fred/...`. Verified timeout propagation by inspecting the `c.client` initialization in `New`.

---
*PR created automatically by Jules for task [9327191336821041760](https://jules.google.com/task/9327191336821041760) started by @styner32*