### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing HTTP timeouts (DoS risk)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-24 - [Missing HTTP Timeouts]
+
+**Vulnerability:** External API requests in `binance` and `fred` packages used `http.Get` which lacks a timeout.
+**Learning:** `http.Get` can hang indefinitely if the remote server fails to respond, leading to resource exhaustion (DoS) when many requests accumulate. Even when a struct has an initialized `*http.Client` with a timeout, it is easy to accidentally bypass it and call `http.Get` instead.
+**Prevention:** Always explicitly create an `http.Client` with a timeout or use a properly initialized struct client when calling external APIs.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,10 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Security: Use custom client with timeout to prevent DoS via hanging connections
+	client := &http.Client{Timeout: 20 * time.Second}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,9 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+
+	// Security: Use initialized client with timeout to prevent DoS via hanging connections
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** External API requests used the default `http.Get()`, which lacks a timeout.
🎯 **Impact:** If the external API hangs or responds slowly, connections can stay open indefinitely, leading to resource exhaustion and a Denial of Service (DoS).
🔧 **Fix:** Replaced `http.Get()` with explicit `http.Client` usage enforcing a 20-second timeout.
✅ **Verification:** Verify that `binance` and `fred` packages compile and tests pass successfully.

---
*PR created automatically by Jules for task [15656759909242986778](https://jules.google.com/task/15656759909242986778) started by @styner32*