### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent DoS by enforcing HTTP client timeouts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-05-08 - Unsafe Default HTTP Client Usage
+**Vulnerability:** Use of package-level `http.Get` without timeouts, which can lead to resource exhaustion (DoS) if external APIs hang.
+**Learning:** Even when custom clients with timeouts are instantiated (as in FRED client), developers might accidentally fall back to `http.Get`.
+**Prevention:** Always use custom `http.Client` instances with explicit `Timeout` configurations and ensure they are invoked instead of default package-level HTTP functions.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,11 +8,16 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
 
 var allowedCryptos = []string{"BTC", "ETH", "SOL", "XRP", "APT", "POL"}
+
+var httpClient = &http.Client{
+	Timeout: 10 * time.Second,
+}
 
 func GetCryptoRSI(crypto string) (float64, error) {
 	if !slices.Contains(allowedCryptos, strings.ToUpper(crypto)) {
@@ -21,7 +26,8 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+	// Security: Use custom client with explicit timeout to prevent resource exhaustion (DoS)
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom client with explicit timeout to prevent resource exhaustion (DoS)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Use of package-level `http.Get` which lacks timeouts and can lead to resource exhaustion.
🎯 Impact: External API hangs could cause the application to run out of resources (Denial of Service).
🔧 Fix: Replaced `http.Get` with custom HTTP clients that have explicit timeouts configured.
✅ Verification: Ran `go build ./internal/pkg/...` to ensure external API calls compile correctly, and checked syntax and logic changes. Tests confirm the custom clients are now used.

---
*PR created automatically by Jules for task [10000204688600220009](https://jules.google.com/task/10000204688600220009) started by @styner32*