### PR TITLE
🛡️ Sentinel: Add missing HTTP timeouts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-03-22 - [Missing HTTP Timeouts]
+
+**Vulnerability:** External API requests in `internal/pkg/fred/api.go` were using default HTTP clients (`http.Get`) without explicit timeouts.
+**Learning:** Failing to set timeouts on external network requests can lead to resource exhaustion (Denial of Service) if the remote server hangs or is slow to respond, tying up goroutines and server resources indefinitely.
+**Prevention:** Always use a custom `http.Client` with a configured `Timeout` explicitly (e.g., `client := &http.Client{Timeout: 10 * time.Second}`) when making external requests. Avoid default package-level functions like `http.Get`.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom client with explicit timeout to prevent resource exhaustion
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** External API requests were using the default `http.Get` which lacks a timeout.
🎯 **Impact:** If the external API (e.g., FRED) hangs or takes an excessive amount of time to respond, the goroutine making the request blocks indefinitely. This can lead to resource exhaustion and a Denial of Service (DoS) vulnerability.
🔧 **Fix:** Replaced package-level `http.Get` calls with custom `http.Client` instances configured with explicit timeouts.
✅ **Verification:** Verify that the code compiles successfully and that tests for the relevant packages pass.

---
*PR created automatically by Jules for task [10245056482425926505](https://jules.google.com/task/10245056482425926505) started by @styner32*