### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix default http.Get usage in FRED API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2025-03-08 - Use Custom HTTP Client with Timeout
+**Vulnerability:** The default `http.Get` does not enforce a timeout, creating a risk for Denial of Service (DoS) and resource exhaustion if the remote server hangs.
+**Learning:** Even when a custom `http.Client` is initialized in a struct, it can be easily missed and the default `http.Get` used by mistake.
+**Prevention:** Always verify that the initialized custom client is the one actually used for making requests (e.g., `c.client.Get()`).

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use the custom client with a configured timeout to prevent resource exhaustion/DoS if the remote server hangs.
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Default `http.Get` is used, which lacks a timeout.
🎯 Impact: If the FRED API hangs or is slow, the application could face resource exhaustion (DoS).
🔧 Fix: Modified `GetHighYieldSpread` to use the pre-configured custom HTTP client (`c.client.Get`) that enforces a timeout. Added a comment documenting the security benefit.
✅ Verification: Run `go build ./internal/pkg/fred/...` to verify the fix compiles.

---
*PR created automatically by Jules for task [255809439962121987](https://jules.google.com/task/255809439962121987) started by @styner32*