### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix HTTP client timeout bypass in FRED API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-11 - [HTTP Client Timeout Bypass]
+**Vulnerability:** External API calls using default `http.Get` without a timeout, leading to potential Denial of Service (DoS) and resource exhaustion if the external API hangs.
+**Learning:** A secure `http.Client` with a timeout was instantiated in the `New` constructor but was ignored in the method implementation, bypassing the intended security mechanism.
+**Prevention:** Always enforce the use of the struct's custom HTTP client (`c.client.Get`) instead of standard package-level functions (`http.Get`) for all external API requests.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom client to enforce timeout and prevent DoS from hanging connections
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Used `http.Get(url)` instead of `c.client.Get(url)` which bypassed the 20-second timeout configured in `New()`. This exposes the application to resource exhaustion and DoS vulnerabilities if the external FRED API hangs.
🎯 Impact: An attacker or a network anomaly causing the FRED API to hang indefinitely would cause the application's goroutines and file descriptors to leak, leading to a complete Denial of Service.
🔧 Fix: Replaced `http.Get(url)` with `c.client.Get(url)` to enforce the 20-second timeout. Added an inline comment documenting the security requirement.
✅ Verification: Ensure the codebase compiles via `go build ./internal/pkg/fred/...` and that the correct `http.Client` method is used.

---
*PR created automatically by Jules for task [4412595561956959308](https://jules.google.com/task/4412595561956959308) started by @styner32*