### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeouts on external API calls

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2023-10-27 - [Default HTTP Client Timeout Risk]
+**Vulnerability:** External API calls in `internal/pkg/binance` and `internal/pkg/fred` used the default `http.Get`, which lacks a timeout configuration, exposing the application to Resource Exhaustion (DoS) risks if the external API hangs.
+**Learning:** Always use a custom `http.Client` with an explicit `Timeout` for all external API interactions to ensure fail-safe behavior. Even if a custom client is defined in a struct (as in FRED client), it must be explicitly invoked instead of falling back to package-level defaults.
+**Prevention:** Instantiate and use custom `http.Client` configurations with explicit timeouts instead of standard package-level `http.Get` or `http.Post` methods.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,13 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Security: using a custom http.Client with an explicit timeout prevents Resource Exhaustion (DoS)
+	// vulnerabilities if external APIs hang.
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,9 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: using the configured c.client with an explicit timeout prevents Resource Exhaustion (DoS)
+	// vulnerabilities if external APIs hang.
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: External API calls to Binance and FRED APIs were using default `http.Get`, which lacks a timeout. This could lead to resource exhaustion if the APIs hang.
🎯 Impact: Missing timeouts can cause goroutines to hang indefinitely, potentially leading to denial of service (DoS) and application instability.
🔧 Fix: Updated the Binance API client to use a custom `http.Client` with a 10-second timeout and corrected the FRED API client to use its predefined custom client. Added security context comments.
✅ Verification: Run `go test ./internal/pkg/...` and `go build ./internal/pkg/...` to ensure everything compiles and runs successfully.

---
*PR created automatically by Jules for task [17889799146274478337](https://jules.google.com/task/17889799146274478337) started by @styner32*