### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Resource Exhaustion via Default HTTP Client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-24 - [Missing Timeout on External API Calls]
+
+**Vulnerability:** The application was using the default `http.Get` which has no timeout, leading to potential indefinite blocking on external API calls to Binance and FRED.
+**Learning:** Using the default `http.Client` (which `http.Get` uses under the hood) without a timeout can lead to resource exhaustion and eventual Denial of Service (DoS) if the target server hangs or fails to respond.
+**Prevention:** Always use a custom `http.Client` with an explicitly configured `Timeout` field for all external API calls.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,8 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,7 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
- 🚨 Severity: MEDIUM
- 💡 Vulnerability: The application was using the default `http.Get` which has no timeout, leading to potential indefinite blocking on external API calls.
- 🎯 Impact: If the external API hangs, goroutines block indefinitely, leading to memory/goroutine leaks and eventual Denial of Service (DoS).
- 🔧 Fix: Replaced `http.Get` with custom `http.Client` instances configured with explicit timeouts in `binance` and `fred` packages.
- ✅ Verification: Run `go build ./internal/pkg/binance/... ./internal/pkg/fred/...` and review the code.

---
*PR created automatically by Jules for task [14492386083572427067](https://jules.google.com/task/14492386083572427067) started by @styner32*