### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS risk by using configured HTTP client instead of default http.Get

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-05-14 - Replace default http.Get with custom HTTP client
+**Vulnerability:** The default `http.Get` and `http.Post` functions in Go's `net/http` package do not have timeouts configured by default. This can cause the application to hang indefinitely if the external API does not respond, leading to resource exhaustion and a potential Denial of Service (DoS) vulnerability.
+**Learning:** Even when a custom `http.Client` with a timeout is defined (as in `New(apiKey string) *FREDClient`), it must be explicitly invoked (e.g., `c.client.Get()`). Developers might accidentally fall back to the package-level `http.Get()`.
+**Prevention:** Always use a custom `http.Client` with an explicit `Timeout` configured for external API calls, and ensure that the custom client is the one actually being used to make the requests.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,9 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+
+	// SECURITY: Use configured custom client with timeout instead of default http.Get
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The application used the default `http.Get` function from Go's `net/http` package to call the FRED API. The default HTTP client does not have a configured timeout, meaning if the external API hangs, the request can block indefinitely, leading to resource exhaustion and potential Denial of Service (DoS).
🎯 **Impact:** An attacker could potentially trigger these external API calls repeatedly while the external service is slow or unresponsive, consuming all available connections and memory, taking down the application.
🔧 **Fix:** Replaced `http.Get` with `c.client.Get` to utilize the `FREDClient`'s custom HTTP client, which is explicitly initialized with a 20-second timeout.
✅ **Verification:** Verified by ensuring the code successfully builds (`go build ./...`). The changes correctly utilize the context/timeout wrapper. Added a critical security learning entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5471013471593183911](https://jules.google.com/task/5471013471593183911) started by @styner32*