### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unbounded HTTP request in FRED client (Resource Exhaustion risk)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-15 - [Medium] Fix unbounded HTTP request in FRED client
+**Vulnerability:** External API requests were made using `http.Get` which has no timeout, leading to potential resource exhaustion (DoS) if the external server hangs. This occurred despite an HTTP client with a timeout already being configured on the `FREDClient` struct.
+**Learning:** Developers frequently bypass securely configured class/struct-level HTTP clients by accidentally falling back to familiar package-level methods like `http.Get`.
+**Prevention:** Ensure static analysis rules (like `gosec`) are configured to block package-level `http.Get` and `http.Post` in favor of explicitly passed or struct-bound HTTP clients.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security Fix: Use custom configured client to prevent resource exhaustion from hanging requests
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `FREDClient.GetHighYieldSpread` method used `http.Get` which lacks a timeout, rather than the properly configured `c.client` that has a 20-second timeout.
🎯 Impact: If the St. Louis Fed API hangs or becomes unresponsive, the goroutine waiting for the response will block indefinitely, leading to resource exhaustion and potential Denial of Service (DoS).
🔧 Fix: Replaced `http.Get(url)` with `c.client.Get(url)` to utilize the custom client's timeout setting, and added a security comment.
✅ Verification: Run `go test ./internal/pkg/fred/...` or `go build ./internal/pkg/fred/...` to verify successful compilation and no regressions.

---
*PR created automatically by Jules for task [8658504090493912706](https://jules.google.com/task/8658504090493912706) started by @styner32*