### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS risk by enforcing HTTP client timeouts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-03-21 - [HTTP Client Timeout DoS Risk]
+
+**Vulnerability:** The application used `http.Get()` from the default `net/http` package without explicit timeouts.
+**Learning:** The default `http.Get()` client lacks timeouts, meaning if the external API hangs, the application's connection will hang indefinitely, potentially leading to resource exhaustion (DoS).
+**Prevention:** Always instantiate a custom `http.Client` with an explicit `Timeout` (e.g., `&http.Client{Timeout: 20 * time.Second}`) for any external API requests.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,11 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	client := &http.Client{
+		Timeout: 20 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,7 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Used `http.Get()` from the default `net/http` package without explicit timeouts.
🎯 Impact: If the external API hangs, the application's connection hangs indefinitely. This can lead to resource exhaustion (e.g. running out of file descriptors or goroutines) resulting in a Denial of Service (DoS) and application crash.
🔧 Fix: Replaced default `http.Get()` calls with custom `http.Client` instances configured with explicit timeouts (20 seconds).
✅ Verification: Ran `go test ./internal/pkg/...` successfully and verified compilation via `go build`.

---
*PR created automatically by Jules for task [13514419440901602340](https://jules.google.com/task/13514419440901602340) started by @styner32*