### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeout on FRED API client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2025-03-03 - [Missing HTTP Client Timeout in FRED API]
+**Vulnerability:** The `FREDClient.GetHighYieldSpread` method used the default `http.Get`, ignoring the custom `http.Client` initialized with a 20-second timeout.
+**Learning:** Even when a secure custom client is configured in a constructor, developers may accidentally use the package-level `http.Get`, leading to potential resource exhaustion (DoS) if the external API hangs.
+**Prevention:** Always ensure custom `http.Client` instances are actually used (`c.client.Get`) instead of the default `http.Get`. Consider using linters like `gosec` to catch usage of default HTTP clients.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// SECURITY: Use custom client with timeout instead of default http.Get to prevent resource exhaustion/DoS if API hangs
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Used default `http.Get` instead of the configured custom client, missing the intended 20-second timeout.
🎯 Impact: If the external FRED API hangs, the application's goroutines could block indefinitely, leading to resource exhaustion (DoS).
🔧 Fix: Changed `http.Get(url)` to `c.client.Get(url)` to enforce the configured timeout.
✅ Verification: Compiled successfully (`go build`) and tests passed (`go test`).

---
*PR created automatically by Jules for task [1272727796172774997](https://jules.google.com/task/1272727796172774997) started by @styner32*