### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing HTTP timeout in FRED API client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-24 - [Missing HTTP Timeout in External API Call]
+
+**Vulnerability:** The application was using the default `http.Get` which does not have a timeout configured. This can lead to resource exhaustion (Denial of Service) if the external API hangs, tying up goroutines and file descriptors indefinitely.
+**Learning:** Even if a custom HTTP client with a timeout is initialized in the constructor (e.g., `New()` returning a struct with a `client` field), it is easy to accidentally bypass it and use `http.Get()` inside the struct's methods.
+**Prevention:** Always ensure custom `http.Client` instances are explicitly invoked (e.g., `c.client.Get()`). Avoid using the default package-level `http.Get` or `http.Post`.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use configured client with timeout instead of default http.Get to prevent resource exhaustion
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The FRED API client was using the default `http.Get`, which lacks a timeout, potentially leading to resource exhaustion (DoS) if the external API hangs.
🎯 Impact: If the FRED API becomes unresponsive, the application could accumulate blocked goroutines and file descriptors, eventually causing a denial of service or out-of-memory errors.
🔧 Fix: Replaced `http.Get` with `c.client.Get`, which uses the properly configured `http.Client` with a 20-second timeout.
✅ Verification: Run `go test ./internal/pkg/fred/...` to verify the client works as expected.

---
*PR created automatically by Jules for task [4223773076763349448](https://jules.google.com/task/4223773076763349448) started by @styner32*