### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Resource Exhaustion Vulnerability in FRED API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-24 - [Resource Exhaustion via Default HTTP Client]
+
+**Vulnerability:** The `internal/pkg/fred/api.go` package used `http.Get` directly. The default `http` package client does not have a configured timeout, which can lead to hanging connections and potential resource exhaustion (Denial of Service) if the external API is slow or unresponsive.
+**Learning:** Even when a custom `http.Client` is initialized in a struct, it's easy to accidentally fallback to the package-level `http.Get` out of habit, leaving the application vulnerable.
+**Prevention:** Always ensure external API calls use the explicitly configured custom HTTP client (e.g., `c.client.Get`) and never rely on the default `http` package functions for network requests.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -3,7 +3,6 @@ package fred
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"strconv"
@@ -49,21 +48,16 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom client with configured timeout instead of default http.Get to prevent DoS via hanging connections
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
 	res := &HighYieldSpreadResponse{}
-
-	if err := json.Unmarshal(body, &res); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `FREDClient` used the default `http.Get` which lacks a timeout, risking resource exhaustion if the API hangs. Also used `io.ReadAll` which risks memory exhaustion.
🎯 Impact: Denial of Service (DoS) due to leaked connections/goroutines or Out-of-Memory (OOM) due to large payloads.
🔧 Fix: Replaced `http.Get` with the configured `c.client.Get` (20s timeout) and streamed the response body with `json.NewDecoder`.
✅ Verification: Review the code changes ensuring `c.client.Get` and `json.NewDecoder` are used. Run tests to confirm functionality is preserved.

---
*PR created automatically by Jules for task [10897787566920381593](https://jules.google.com/task/10897787566920381593) started by @styner32*