### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability by using configured HTTP client

### DIFF
--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,9 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+
+	// SECURITY: Use configured client with timeout to prevent DoS via resource exhaustion
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `GetHighYieldSpread` function was using the default `http.Get` which lacks a timeout, making the application vulnerable to resource exhaustion (Denial of Service) if the external API hangs or responds very slowly.
🎯 Impact: A hanging external API call can cause goroutines and file descriptors to leak indefinitely, eventually crashing the application.
🔧 Fix: Replaced `http.Get` with the already pre-configured `c.client.Get`, which sets a 20-second timeout. Added an explanatory security comment.
✅ Verification: Successfully compiled the package (`go build ./internal/pkg/fred/...`) and verified tests (if applicable) pass without error.

---
*PR created automatically by Jules for task [13040827550363300336](https://jules.google.com/task/13040827550363300336) started by @styner32*