### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix default HTTP client usage without timeout

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-05-23 - Default HTTP Client Timeout Vulnerability
+**Vulnerability:** Default HTTP clients (`http.Get`) were used for external API calls, which lack a default timeout.
+**Learning:** External API dependencies can hang indefinitely. Using the default `http.Client` (or `http.Get`/`http.Post`) in Go leaves the application vulnerable to resource exhaustion if the remote server fails to respond.
+**Prevention:** Always use a custom `http.Client` with an explicitly defined `Timeout` field for any external network communication.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,9 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Sentinel Security Recommendation: Ensure we use the custom HTTP client with an explicit timeout
+	// to avoid indefinite hangs from the external API (DoS risk).
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: A default HTTP client (`http.Get`) was used to make requests to the FRED API instead of the configured client with a timeout.
🎯 Impact: If the external API hangs or responds slowly, the application's connections could remain open indefinitely, leading to resource exhaustion and potential Denial of Service (DoS).
🔧 Fix: Replaced `http.Get` with `c.client.Get`, which is configured with an explicit 20-second timeout.
✅ Verification: Code compiles successfully. Running `go test ./internal/pkg/fred/...` for the modified packages shows no regressions.

---
*PR created automatically by Jules for task [17015242071875172567](https://jules.google.com/task/17015242071875172567) started by @styner32*