### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability by enforcing HTTP client timeout

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-24 - Enforce HTTP Client Timeouts
+**Vulnerability:** The `internal/pkg/fred` package was using `http.Get` instead of a custom configured client. This default client has no timeout, leading to potential resource exhaustion (DoS) if the external API hangs.
+**Learning:** Always use a custom `http.Client` with an explicit `Timeout` configured for external API calls, and ensure the client is invoked explicitly (e.g., `client.Get()`).
+**Prevention:** Avoid using default package-level `http.Get` or `http.Post`. Define a custom client structure and invoke its methods.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use configured client with timeout instead of default http.Get to prevent DoS (resource exhaustion) if the external API hangs.
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The FRED API client was using the default `http.Get` which has no timeout, making the application vulnerable to resource exhaustion (DoS) if the API hangs.
🎯 Impact: The application could hang indefinitely, exhausting goroutines and memory.
🔧 Fix: Changed the API call to use the custom configured `c.client.Get(url)` with a 20-second timeout.
✅ Verification: Ran `go build ./internal/pkg/fred/...` and `go test ./internal/pkg/...` to ensure no build breaks or test regressions.

---
*PR created automatically by Jules for task [10798566538461009389](https://jules.google.com/task/10798566538461009389) started by @styner32*