### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Resource Exhaustion in FRED API Client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-05-26 - [Missing Timeouts on External HTTP Calls]
+
+**Vulnerability:** The codebase was found using the default `http.Get()` in API client functions (like `GetHighYieldSpread`). The default HTTP client does not configure any timeouts. If the external API hangs or responds extremely slowly, the connection will stay open indefinitely, leading to resource exhaustion (DoS) via goroutine and file descriptor leaks.
+**Learning:** Default global HTTP functions in Go (e.g., `http.Get`, `http.Post`) should never be used in production applications making outbound requests to third parties due to their lack of bounds/timeouts. Even when a struct wraps a custom `http.Client` with timeouts configured, it's easy to accidentally call the package-level `http.Get` instead of the custom receiver (`c.client.Get`).
+**Prevention:** Always instantiate a custom `http.Client` with explicit `Timeout` values set and strictly enforce its use over package-level defaults. Consider linters like `gosec` or `bodyclose` to detect usages of default clients.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Use custom client with explicit timeout to prevent DoS from hanging API calls
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `GetHighYieldSpread` function in `internal/pkg/fred/api.go` used the default `http.Get()`, which has no timeout. This can cause the application to hang indefinitely if the external FRED API is unresponsive, leading to resource exhaustion (DoS) through goroutine and connection leaks.
🎯 Impact: Attackers or upstream API failures could cause the service to run out of memory or file descriptors, bringing down the application.
🔧 Fix: Replaced the default `http.Get(url)` call with `c.client.Get(url)`, utilizing the existing `FREDClient`'s configured custom `http.Client` which has a 20-second timeout. Added a comment explaining the security rationale.
✅ Verification: Ran `go build ./internal/pkg/fred/...` and `go test ./...` to verify compilation and prevent regressions. Reviewers can verify the timeout behavior is enforced by the custom client configured in `New()`.

---
*PR created automatically by Jules for task [10812644910673148453](https://jules.google.com/task/10812644910673148453) started by @styner32*