### PR TITLE
🛡️ Sentinel: [HIGH] Fix resource exhaustion vulnerability in Binance API client

### DIFF
--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,13 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// SECURITY: Use custom HTTP client with explicit timeout to prevent resource exhaustion (DoS)
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The Binance API client used the default `http.Get` which lacks a timeout, leaving the application vulnerable to resource exhaustion (DoS) if the external API hangs.
🎯 Impact: If the external Binance API hangs or becomes unresponsive, the application's goroutines could block indefinitely, eventually exhausting system resources and causing a Denial of Service.
🔧 Fix: Implemented a custom `http.Client` with an explicit 10-second timeout.
✅ Verification: Verified by running `go build ./internal/pkg/binance/...` and `go test ./internal/pkg/...`.

---
*PR created automatically by Jules for task [16672777031622707644](https://jules.google.com/task/16672777031622707644) started by @styner32*