### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix resource exhaustion vulnerability in FRED API

### DIFF
--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,9 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+
+	// Use custom client with timeout to prevent resource exhaustion (DoS) if the external API hangs.
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
- 🚨 Severity: MEDIUM
- 💡 Vulnerability: Usage of default `http.Get` without a timeout leaves the application vulnerable to resource exhaustion (DoS) if the external FRED API hangs.
- 🎯 Impact: A hanging API request could tie up a goroutine indefinitely, leading to memory leaks and eventual application crash (OOM).
- 🔧 Fix: Updated `GetHighYieldSpread` to use the pre-configured `c.client` (which has a 20s timeout) instead of the default package-level `http.Get`.
- ✅ Verification: Compiled and tested the `internal/pkg/...` packages successfully.

---
*PR created automatically by Jules for task [1740767518359294441](https://jules.google.com/task/1740767518359294441) started by @styner32*