### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability by adding HTTP timeout in binance client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+## 2025-05-29 - Default HTTP Client Timeout Vulnerability
+**Vulnerability:** The `http.Get` function was used in `internal/pkg/binance/api.go` without a timeout configuration.
+**Learning:** Using Go's default `http.Get` or an `http.Client` without an explicit `Timeout` leaves applications vulnerable to resource exhaustion (Denial of Service) if external APIs hang and connections remain open indefinitely.
+**Prevention:** Always use a custom `http.Client` with a defined `Timeout` (e.g., `Timeout: 10 * time.Second`) for external HTTP requests to ensure connections are appropriately bounded.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,13 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// SECURITY: Use custom http.Client with explicit timeout to prevent
+	// resource exhaustion (DoS) if the external Binance API hangs.
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Use of default `http.Get` without a timeout leaves the application vulnerable to resource exhaustion (DoS) if the external Binance API hangs.
🎯 Impact: A hanging external API could cause the application to consume all available connections/threads, leading to a Denial of Service (DoS).
🔧 Fix: Replaced `http.Get` with a custom `http.Client` explicitly configured with a 10-second `Timeout`.
✅ Verification: Ran `go test ./internal/pkg/...` and `go build ./internal/pkg/...` to verify the code compiles and tests pass without regressions.

---
*PR created automatically by Jules for task [11212792814507792074](https://jules.google.com/task/11212792814507792074) started by @styner32*