### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeout on FRED API client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-03-24 - [Uncontrolled Resource Consumption in FRED API Client]
+
+**Vulnerability:** The `FREDClient.GetHighYieldSpread` method used the default package-level `http.Get`, which lacks a timeout. If the external FRED API hangs or delays its response, the request will block indefinitely, leading to resource exhaustion (Denial of Service).
+**Learning:** Even when a custom `http.Client` with a configured timeout is provided in a struct (as in `FREDClient`), it must be explicitly used. Failing to use it (e.g., mistakenly calling `http.Get`) silently introduces vulnerability to DoS.
+**Prevention:** Always ensure that network requests to external APIs are made using a custom `http.Client` explicitly configured with a `Timeout`. Never use the default package-level `http.Get` or `http.Post` in production code.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// SECURITY: Use custom client with configured timeout to prevent resource exhaustion (DoS)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `FREDClient.GetHighYieldSpread` function uses the default package-level `http.Get`, which lacks a timeout.
🎯 Impact: If the external FRED API hangs, the request will wait indefinitely, consuming resources and potentially causing a Denial of Service (DoS) via resource exhaustion.
🔧 Fix: Changed to use the struct's pre-configured `c.client.Get()` which enforces a 20-second timeout.
✅ Verification: Successfully built the `fred` package locally to ensure there are no syntax errors and ran tests.

---
*PR created automatically by Jules for task [18377155091707912986](https://jules.google.com/task/18377155091707912986) started by @styner32*