### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix resource exhaustion in FRED client

### DIFF
--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use configured client with timeout to prevent resource exhaustion (DoS)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
* 🚨 Severity: MEDIUM
* 💡 Vulnerability: `http.Get` was used without a timeout, leading to potential resource exhaustion if the external API hangs.
* 🎯 Impact: DoS or memory exhaustion due to hanging goroutines.
* 🔧 Fix: Replaced `http.Get` with the configured `c.client.Get` which has a 20s timeout. Added a specific security comment.
* ✅ Verification: Verified compilation and ran tests. code compiles perfectly.

---
*PR created automatically by Jules for task [5309232580688941447](https://jules.google.com/task/5309232580688941447) started by @styner32*