### PR TITLE
🛡️ Sentinel: [MEDIUM] Add timeout to Binance API HTTP client

### DIFF
--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,12 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Security: Use custom HTTP client with timeout to prevent resource exhaustion (DoS) if external API hangs
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `http.Get` method was used without a timeout configured.
🎯 Impact: If the Binance API hangs or responds slowly, the underlying TCP connections can remain open indefinitely, leading to resource exhaustion (Denial of Service) in the application.
🔧 Fix: Replaced package-level `http.Get` with a custom `http.Client` configured with a 10-second `Timeout`.
✅ Verification: Compile the package (`go build ./internal/pkg/binance/...`) and verify the Binance API fetch still functions under normal conditions with tests (`go test ./internal/pkg/binance/...`).

---
*PR created automatically by Jules for task [15771562730073297576](https://jules.google.com/task/15771562730073297576) started by @styner32*