### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability due to missing HTTP timeout

### DIFF
--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,10 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// SECURITY: Use custom client with timeout to prevent resource exhaustion (DoS)
+	client := &http.Client{Timeout: 20 * time.Second}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// SECURITY: Use custom client with timeout to prevent resource exhaustion (DoS)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application used the default package-level `http.Get` which lacks a timeout configuration for external API requests to FRED and Binance.
🎯 Impact: If the external API hangs indefinitely or responds extremely slowly, the application threads waiting on the HTTP response could be held indefinitely, leading to resource exhaustion and potential Denial of Service (DoS) for the application.
🔧 Fix: Replaced `http.Get` with custom HTTP clients configured with an explicit 20-second timeout, ensuring the requests will eventually fail and free up resources if the upstream servers hang.
✅ Verification: Successfully compiled and tested the packages locally.

---
*PR created automatically by Jules for task [7776907851895566948](https://jules.google.com/task/7776907851895566948) started by @styner32*