### PR TITLE
🛡️ Sentinel: Enforce HTTP timeouts on external API calls

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-10-18 - [Missing HTTP Timeout for External API Calls]
+
+**Vulnerability:** External API calls to FRED and Binance APIs used the global `http.Get` which does not enforce any timeout by default.
+**Learning:** Using default `http` package global methods (like `http.Get`) without a custom configured `http.Client` can cause goroutines to block indefinitely if the external service hangs, leading to resource exhaustion (Denial of Service) and Out-Of-Memory (OOM) errors.
+**Prevention:** Always use a custom `http.Client` with an explicit `Timeout` set (e.g., `client := &http.Client{Timeout: 10 * time.Second}`) for any network requests to external dependencies.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,9 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+	// SECURITY: Use custom client with configured timeout to prevent resource exhaustion
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// SECURITY: Use custom client with configured timeout to prevent resource exhaustion
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP timeouts on external API calls to FRED and Binance.
🎯 Impact: If the external APIs hang or become unresponsive, the application's goroutines could block indefinitely, leading to resource exhaustion (DoS) or memory exhaustion.
🔧 Fix: Replaced default `http.Get` calls with custom `http.Client` instances configured with explicit timeouts (20s for FRED, 10s for Binance). Added security comments explaining the fix.
✅ Verification: Ran `go build` and `go test` on the affected packages to ensure they compile and tests pass successfully.

---
*PR created automatically by Jules for task [15856252609989957996](https://jules.google.com/task/15856252609989957996) started by @styner32*