### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix resource exhaustion risk by using configured HTTP client

### DIFF
--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom HTTP client with timeout instead of default http.Get to prevent potential Denial of Service (DoS) via resource exhaustion
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `GetHighYieldSpread` function uses the default `http.Get`, which lacks a timeout. This can lead to resource exhaustion and potential Denial of Service (DoS) if the external API hangs.
🎯 Impact: A hanging external API call could tie up system resources (goroutines, file descriptors, memory), potentially leading to a Denial of Service.
🔧 Fix: Changed `http.Get` to use the pre-configured `c.client.Get`, which has a 20-second timeout. Added a security comment explaining the fix.
✅ Verification: Verified compilation via `go build ./internal/pkg/fred/...` and ran `go test ./internal/pkg/...` to ensure no regressions.

---
*PR created automatically by Jules for task [9517020514059774741](https://jules.google.com/task/9517020514059774741) started by @styner32*