### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS risk in FRED API client

### DIFF
--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom client with explicit timeout to prevent DoS (Denial of Service)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
**🚨 Severity:** MEDIUM
**💡 Vulnerability:** The `GetHighYieldSpread` function uses the default `http.Get` which lacks a timeout configuration, posing a DoS risk if the external API hangs.
**🎯 Impact:** If the FRED API takes too long to respond, the application could experience resource exhaustion or hang indefinitely.
**🔧 Fix:** Modified the HTTP call to use the custom `c.client` with an explicit 20-second timeout.
**✅ Verification:** Compiled the package using `go build ./internal/pkg/fred/...` and verified tests using `go test ./internal/pkg/...`.

---
*PR created automatically by Jules for task [15900488420952890814](https://jules.google.com/task/15900488420952890814) started by @styner32*