### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeouts in HTTP requests (DoS risk)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-06-07 - [Missing External API Timeouts]
+**Vulnerability:** The application used default `http.Get` for calling external APIs (Binance, FRED). The default Go HTTP client has no timeout, meaning if the external server hangs, the goroutine is blocked indefinitely. This can lead to connection pool exhaustion and application crashes (Denial of Service).
+**Learning:** Default HTTP clients in standard libraries often lack robust defaults for production systems, specifically timeouts.
+**Prevention:** Always instantiate a custom `http.Client` with an explicit `Timeout` configured for any external API calls. Ensure this custom client is explicitly invoked instead of using package-level convenience methods.

--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,10 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Security Fix: Use custom client with explicit timeout to prevent DoS via resource exhaustion
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security Fix: Use custom client with explicit timeout to prevent DoS via resource exhaustion
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Default `http.Get` used for external API calls lacks a timeout, leaving the application vulnerable to resource exhaustion (DoS) if the external server hangs.
🎯 Impact: If the Binance or FRED APIs hang indefinitely, the application's goroutines will be blocked, potentially leading to connection pool exhaustion and application crashes.
🔧 Fix: Replaced `http.Get` with a custom `http.Client` with an explicit 10-second timeout in Binance API, and used the existing `c.client` (which has a 20s timeout) in FRED API.
✅ Verification: Verified code compilation and tests.

---
*PR created automatically by Jules for task [11842442991862303819](https://jules.google.com/task/11842442991862303819) started by @styner32*