### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix default HTTP client usage lacking timeouts

### DIFF
--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,10 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// 🛡️ SECURITY: Use custom client with timeout instead of default http.Get to prevent DoS from hanging external APIs
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,9 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+
+	// 🛡️ SECURITY: Use custom client with timeout instead of default http.Get to prevent DoS from hanging external APIs
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: External API calls to FRED and Binance were using the default `http.Get()`, which lacks a timeout.
🎯 Impact: If the external APIs hang or respond slowly, the application could suffer from resource exhaustion and Denial of Service (DoS) as connections are held indefinitely.
🔧 Fix: Replaced `http.Get()` with custom `http.Client` instances configured with explicit timeouts (using the existing `c.client` for FRED and a new 10-second client for Binance) and added inline security comments.
✅ Verification: Ran `go build ./internal/pkg/...` and `go test ./internal/pkg/...` to verify successful compilation and no regressions in the API packages.

---
*PR created automatically by Jules for task [6448374544709689779](https://jules.google.com/task/6448374544709689779) started by @styner32*