### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeouts on external API calls

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-06-09 - [Missing Timeouts on HTTP Requests]
+**Vulnerability:** The application used the default package-level `http.Get` function to make external API calls (e.g., to FRED or Binance). The default HTTP client in Go has no timeout configured.
+**Learning:** Using `http.Get` without a timeout is a severe risk. If the external server hangs or responds slowly, the goroutine making the request will block indefinitely. In a web server context, this can quickly lead to goroutine exhaustion and a Denial of Service (DoS).
+**Prevention:** Always use a custom `http.Client` with an explicit `Timeout` configured (e.g., `client := &http.Client{Timeout: 10 * time.Second}`) for any external HTTP requests.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security Fix: Use custom client with explicit timeout to prevent DoS via hanging external API calls
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
- **🚨 Severity:** MEDIUM
- **💡 Vulnerability:** The application uses the default package-level `http.Get` which lacks a timeout.
- **🎯 Impact:** If the external API hangs, the application's connections and goroutines will hang indefinitely, potentially leading to resource exhaustion and a Denial of Service (DoS) attack.
- **🔧 Fix:** Replaced `http.Get` with a custom `http.Client` that has an explicit timeout configured.
- **✅ Verification:** Run `go test ./internal/pkg/...` and ensure all tests pass.

---
*PR created automatically by Jules for task [5590609076450553233](https://jules.google.com/task/5590609076450553233) started by @styner32*