### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix default HTTP client usage lacking timeout in FRED client

### DIFF
--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// SECURITY: Use custom client with explicit timeout to prevent DoS/resource exhaustion
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
* 🚨 Severity: MEDIUM
* 💡 Vulnerability: Default `http.Get` lacks a timeout, risking resource exhaustion/DoS.
* 🎯 Impact: External API hangs could cause the service to exhaust file descriptors or memory.
* 🔧 Fix: Use the custom `c.client` with configured `Timeout`.
* ✅ Verification: Verified compilation and ran tests.

---
*PR created automatically by Jules for task [1758651413835596795](https://jules.google.com/task/1758651413835596795) started by @styner32*