### PR TITLE
🛡️ Sentinel: [Medium] Fix missing HTTP timeout configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+## 2026-06-12 - [Missing HTTP Client Timeout]
+
+**Vulnerability:** The FRED API client `GetHighYieldSpread` function used the package-level `http.Get()` which has no timeout. This can lead to resource exhaustion (DoS) if the external API hangs indefinitely, as connections will remain open.
+**Learning:** Even when a struct is instantiated with a custom `http.Client` that has a configured timeout, developers might mistakenly use the package-level `http.Get()` instead of the struct's configured client. Always explicitly use the instantiated custom client (e.g., `c.client.Get()`).
+**Prevention:** Ensure all external API calls are made using a custom `http.Client` with a defined `Timeout` and avoid using the default `http.Get` or `http.Post` package-level functions.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Use custom client with configured timeout to prevent resource exhaustion (DoS) from hanging external APIs.
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The FRED API client was using the default `http.Get` which lacks a configured timeout. This could lead to resource exhaustion (Denial of Service) if the external API hangs indefinitely.
🎯 Impact: Potential resource exhaustion and application unresponsiveness if the FRED API takes too long to respond.
🔧 Fix: Replaced `http.Get` with the `c.client.Get` method, which utilizes the pre-configured `http.Client` with a 20-second timeout.
✅ Verification: Verified by compiling the package and running tests to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [8513665943437629998](https://jules.google.com/task/8513665943437629998) started by @styner32*