### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS risk by enforcing HTTP timeout

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-06-13 - [Denial of Service Prevention via HTTP Timeouts]
+**Vulnerability:** A configured `http.Client` with a timeout was instantiated but the code mistakenly used `http.Get` which has no timeout.
+**Learning:** Even when a struct is created with a secure HTTP client, it's easy to accidentally use the default package-level `http.Get()`. This bypasses timeout configurations and creates resource exhaustion/DoS vulnerabilities.
+**Prevention:** Always verify that configured HTTP clients (`c.client.Get()`) are actually being invoked instead of standard library defaults.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom configured http.Client with timeout instead of default package-level http.Get to prevent DoS from hanging API calls.
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
* 🚨 Severity: MEDIUM
* 💡 Vulnerability: The code used the default `http.Get` which has no timeout, instead of the configured `c.client` with a timeout.
* 🎯 Impact: If the external FRED API hangs or delays indefinitely, the application would exhaust available resources, potentially causing a Denial of Service (DoS).
* 🔧 Fix: Updated the code to use `c.client.Get(url)` and added a security comment explaining the concern.
* ✅ Verification: Ran `go test ./internal/pkg/fred/...` to verify the code compiles and tests pass.

---
*PR created automatically by Jules for task [15278205792328574049](https://jules.google.com/task/15278205792328574049) started by @styner32*