### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing HTTP timeout in Binance API client

### DIFF
--- a/internal/pkg/binance/api.go
+++ b/internal/pkg/binance/api.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const baseURL = "https://api.binance.com"
@@ -21,7 +22,12 @@ func GetCryptoRSI(crypto string) (float64, error) {
 
 	symbol := fmt.Sprintf("%sUSDT", strings.ToUpper(crypto))
 	url := fmt.Sprintf("%s/api/v3/klines?symbol=%s&interval=4h&limit=100", baseURL, symbol)
-	resp, err := http.Get(url)
+
+	// Security: Use custom HTTP client with timeout to prevent DoS from hanging external API calls
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return 0, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP timeout on external API call using `http.Get()`.
🎯 Impact: If the external API (Binance) hangs, the goroutine handling the request could block indefinitely, potentially leading to resource exhaustion (Denial of Service) in the application.
🔧 Fix: Implemented a custom `http.Client` with an explicit 10-second `Timeout`.
✅ Verification: Run `go test ./internal/pkg/binance/...` and observe it passing successfully.

---
*PR created automatically by Jules for task [13421651799019978466](https://jules.google.com/task/13421651799019978466) started by @styner32*