### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeout on FRED API client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-24 - [External API Timeout Vulnerability]
+
+**Vulnerability:** The application used the default `http.Get` in `internal/pkg/fred` to fetch data from an external API. This default client has no configured timeout, making the application vulnerable to resource exhaustion (DoS) if the external API hangs indefinitely, which blocks goroutines and resources.
+**Learning:** Using `http.Get`, `http.Post`, or the default `http.Client` is dangerous in production services as they do not impose timeouts.
+**Prevention:** Always initialize and use a custom `http.Client` with an explicit `Timeout` set (e.g., `Timeout: 20 * time.Second`) for all external API communications to ensure fail-fast behavior and prevent resource locking.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Use custom client with configured timeout to prevent resource exhaustion (DoS) if API hangs
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The FRED API client used the default `http.Get` which lacks a timeout, making it vulnerable to resource exhaustion (DoS) if the external API hangs.
🎯 Impact: A hanging external API call could cause the application's threads and resources to block indefinitely, leading to service degradation or denial of service.
🔧 Fix: Replaced `http.Get(url)` with `c.client.Get(url)` to use the custom client initialized with a 20-second timeout.
✅ Verification: Compiled and tested the `internal/pkg/fred` package successfully.

---
*PR created automatically by Jules for task [12761948256357395490](https://jules.google.com/task/12761948256357395490) started by @styner32*