### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing HTTP timeout in FRED API client

### DIFF
--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,9 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+
+	// Security: Use custom client with explicit timeout to prevent resource exhaustion (DoS)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `GetHighYieldSpread` function uses the default package-level `http.Get` which lacks a timeout, instead of the configured custom `http.Client`.
🎯 Impact: External API hangs or delays can cause the application's goroutines to block indefinitely, potentially leading to resource exhaustion and Denial of Service (DoS).
🔧 Fix: Updated the function to use the pre-configured `c.client.Get(url)` with a defined 20-second timeout, and added a comment explaining the security concern.
✅ Verification: Ensured the codebase compiles and tests pass. The API call is now properly bounded by the timeout.

---
*PR created automatically by Jules for task [15177735447313047659](https://jules.google.com/task/15177735447313047659) started by @styner32*