### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Resource Exhaustion/DoS by using HTTP client with timeout

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2025-02-27 - [Default HTTP Client DoS Vulnerability]
+**Vulnerability:** The `GetHighYieldSpread` function in `internal/pkg/fred/api.go` used the default package-level `http.Get()`, which does not configure any timeout.
+**Learning:** Using `http.Get()`, `http.Post()`, or `http.DefaultClient` for outbound requests to third-party APIs can cause connections to hang indefinitely if the external service becomes unresponsive. This exhausts server resources (e.g., goroutines, file descriptors, memory) leading to a Denial of Service (DoS).
+**Prevention:** Always use a custom initialized `http.Client` with an explicitly configured `Timeout` field (e.g., `&http.Client{Timeout: 20 * time.Second}`) for any external HTTP request.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom HTTP client with timeout to prevent DoS from hanging requests
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `GetHighYieldSpread` function uses the default package-level `http.Get()`, which does not have a timeout.
🎯 Impact: External API hangs or slow responses can leave connections open indefinitely, leading to resource exhaustion and Denial of Service (DoS).
🔧 Fix: Changed `http.Get(url)` to use `c.client.Get(url)` which leverages the initialized custom HTTP client configured with a 20-second timeout.
✅ Verification: Run `go test ./internal/pkg/fred/...` to verify the package compiles and tests pass.

---
*PR created automatically by Jules for task [6346368602264780013](https://jules.google.com/task/6346368602264780013) started by @styner32*