### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Zip Bomb Vulnerability in DART Client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,9 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-20 - [Zip Bomb / Memory Exhaustion Vulnerability]
+
+**Vulnerability:** The DART client decompressed ZIP files directly into a `bytes.Buffer` using `io.Copy` without any size limits. This created a Zip Bomb and memory exhaustion risk, where a malicious or malformed ZIP file could consume excessive amounts of memory, leading to an Out-Of-Memory (OOM) crash.
+**Learning:** Using `io.Copy` on untrusted compressed streams without a bound is dangerous. `io.LimitReader` must be used to strictly bound the maximum number of bytes read into memory.
+**Prevention:** Always use `io.LimitReader` wrapped around compressed file readers, and track the total bytes decompressed across all files in an archive, returning an error if a sensible upper bound (e.g., 100MB) is exceeded.

--- a/internal/pkg/dart/dart.go
+++ b/internal/pkg/dart/dart.go
@@ -150,6 +150,9 @@ func (c *DartClient) GetDocument(rceptNo string) (string, error) {
 		return "", err
 	}
 
+	const maxDecompressedSize = 100 * 1024 * 1024 // 100MB limit
+	var totalRead int64
+
 	outBuf := new(bytes.Buffer)
 	for _, f := range zr.File {
 		rc, err := f.Open()
@@ -157,11 +160,17 @@ func (c *DartClient) GetDocument(rceptNo string) (string, error) {
 			return "", err
 		}
 
-		_, err = io.Copy(outBuf, rc)
+		// Security: Prevent Zip Bomb / memory exhaustion
+		n, err := io.Copy(outBuf, io.LimitReader(rc, maxDecompressedSize-totalRead))
+		rc.Close()
 		if err != nil {
 			return "", err
 		}
-		rc.Close()
+
+		totalRead += n
+		if totalRead >= maxDecompressedSize {
+			return "", fmt.Errorf("decompressed size exceeds limit")
+		}
 	}
 
 	return outBuf.String(), nil
@@ -235,6 +244,9 @@ func (c *DartClient) GetCompanies() ([]Company, error) {
 		return nil, err
 	}
 
+	const maxDecompressedSize = 100 * 1024 * 1024 // 100MB limit
+	var totalRead int64
+
 	outBuf := new(bytes.Buffer)
 	for _, f := range zr.File {
 		rc, err := f.Open()
@@ -242,11 +254,17 @@ func (c *DartClient) GetCompanies() ([]Company, error) {
 			return nil, err
 		}
 
-		_, err = io.Copy(outBuf, rc)
+		// Security: Prevent Zip Bomb / memory exhaustion
+		n, err := io.Copy(outBuf, io.LimitReader(rc, maxDecompressedSize-totalRead))
 		rc.Close()
 
 		if err != nil {
 			return nil, err
+		}
+
+		totalRead += n
+		if totalRead >= maxDecompressedSize {
+			return nil, fmt.Errorf("decompressed size exceeds limit")
 		}
 	}
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The DART client (`internal/pkg/dart/dart.go`) decompressed ZIP files directly into memory without size limits, making the application vulnerable to Zip Bombs and memory exhaustion (OOM).
🎯 Impact: An attacker or a malformed upstream response could provide a highly compressed ZIP file that, when decompressed, consumes all available memory and crashes the application, resulting in a Denial of Service (DoS).
🔧 Fix: Implemented an explicit 100MB decompression limit using `io.LimitReader` and tracked `totalRead` bytes across all files in the archive. Processing stops and returns an error if the limit is exceeded.
✅ Verification: Built the `internal/pkg/...` packages and ran the test suite using `go test ./internal/pkg/...` to confirm no regressions. The decompressed size limits are successfully enforced.

---
*PR created automatically by Jules for task [11923421746948153556](https://jules.google.com/task/11923421746948153556) started by @styner32*