### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// SECURITY: Use custom client with configured timeout to prevent resource exhaustion (DoS) from hanging external APIs
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP timeout configurations in FRED API client (used default `http.Get` instead of the configured custom client).
🎯 Impact: If the external FRED API hangs or delays responses, it could lead to resource exhaustion and Denial of Service (DoS) by keeping HTTP connections indefinitely open.
🔧 Fix: Changed the HTTP call to use the pre-configured `c.client.Get(url)`, which correctly applies a 20-second timeout, and added a security comment.
✅ Verification: Compiled and tested `internal/pkg/fred` to ensure the correct client instance is invoked.

---
*PR created automatically by Jules for task [3476670407112410275](https://jules.google.com/task/3476670407112410275) started by @styner32*