### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix resource exhaustion (DoS) vulnerability in FRED API client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-06-22 - [Resource Exhaustion (DoS) via Unbounded HTTP Requests]
+**Vulnerability:** The application instantiated a custom `http.Client` with a timeout but erroneously used the package-level `http.Get()` for external API calls, bypassing the timeout and exposing the application to Denial of Service (DoS) if the remote API hangs.
+**Learning:** Configuring a secure HTTP client is insufficient if it is not explicitly used. The default `http.Get` lacks timeouts and will block indefinitely.
+**Prevention:** Always invoke the custom client (e.g., `client.Get()`) and prohibit the use of `http.Get()` or `http.Post()` in the codebase.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,9 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// SECURITY: Use the custom client with a configured timeout to prevent resource exhaustion (DoS)
+	// if the external API hangs, avoiding the default package-level http.Get.
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The FRED API client used the default `http.Get` instead of the configured custom client, meaning requests lacked a timeout and could block indefinitely.
🎯 Impact: If the external FRED API hangs or delays responses, the application's threads could become exhausted, leading to a Denial of Service (DoS).
🔧 Fix: Replaced `http.Get(url)` with `c.client.Get(url)` to enforce the configured 20-second timeout.
✅ Verification: Ensured the codebase compiles successfully and uses `c.client.Get`.

---
*PR created automatically by Jules for task [17412212305943228519](https://jules.google.com/task/17412212305943228519) started by @styner32*