### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeout in FRED API client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+## 2026-06-23 - [Missing HTTP Client Timeout]
+
+**Vulnerability:** Using the default HTTP client via `http.Get` or `http.Post` does not enforce any timeouts. This can lead to a Denial of Service (DoS) condition due to resource exhaustion if the external API responds slowly or hangs indefinitely, causing the calling goroutine to block forever.
+**Learning:** Even within simple external API interactions, always use a custom HTTP client configured with explicit timeouts rather than relying on the package-level convenience functions provided by `net/http`.
+**Prevention:** Instantiate and use custom HTTP clients with a defined `Timeout` for all external network requests (e.g., `&http.Client{Timeout: 20 * time.Second}`).

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom client with explicit timeout to prevent resource exhaustion (DoS)
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Default HTTP client usage (`http.Get`) without a timeout configuration.
🎯 Impact: If the external API hangs or responds slowly, the goroutine could block indefinitely, leading to resource exhaustion (DoS).
🔧 Fix: Updated the code to use the struct's custom HTTP client (`c.client`), which is initialized with a 20-second timeout.
✅ Verification: Compiled successfully.

---
*PR created automatically by Jules for task [6273957319928335482](https://jules.google.com/task/6273957319928335482) started by @styner32*