### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix resource exhaustion vulnerability in FRED client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2024-05-27 - [MEDIUM] Fix resource exhaustion vulnerability in FRED client
+**Vulnerability:** The FRED API client (`internal/pkg/fred/api.go`) used the default package-level `http.Get`, which does not have a timeout configured.
+**Learning:** Default HTTP methods like `http.Get` in Go lack timeouts and can cause resource exhaustion (Denial of Service) if external APIs hang indefinitely. While there was a custom configured `c.client` with a timeout, it was not being utilized correctly.
+**Prevention:** Always ensure that custom HTTP clients with explicitly defined timeouts (e.g., `&http.Client{Timeout: 20 * time.Second}`) are invoked (e.g., `c.client.Get(url)`) instead of using the default package-level methods.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// SECURITY: Use custom client with timeout instead of default http.Get to prevent DoS via resource exhaustion
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The FRED client used the default `http.Get` which lacks a timeout, making it vulnerable to resource exhaustion (DoS) if the external API hangs.
🎯 Impact: A hanging external API could cause the server's goroutines and resources to be exhausted, potentially leading to a Denial of Service.
🔧 Fix: Replaced `http.Get` with the existing `c.client.Get` which is configured with a 20-second timeout.
✅ Verification: Tests run successfully, confirming the custom client is utilized correctly.

---
*PR created automatically by Jules for task [8730854106213363584](https://jules.google.com/task/8730854106213363584) started by @styner32*