### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeout in FRED API client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,10 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+## 2025-02-24 - Missing HTTP Client Timeout in FRED API
+
+**Vulnerability:** The FRED API client (`internal/pkg/fred/api.go`) was using the default `http.Get()` function. This function has no timeout configured by default.
+
+**Learning:** When making external API calls in Go, using the default `http` package methods (like `http.Get`, `http.Post`) can lead to resource exhaustion and potential Denial of Service (DoS). If the external server hangs or responds infinitely slowly, the underlying goroutines will be blocked indefinitely waiting for a response, eventually consuming all available resources.
+
+**Prevention:** Always instantiate a custom `http.Client` with an explicit, sensible `Timeout` configured, and use that client's methods (e.g., `client.Get()`) instead of the package-level defaults.

--- a/internal/pkg/fred/api.go
+++ b/internal/pkg/fred/api.go
@@ -49,7 +49,8 @@ func New(apiKey string) *FREDClient {
 
 func (c *FREDClient) GetHighYieldSpread() (map[string]float64, error) {
 	url := fmt.Sprintf("%s/fred/series/observations?series_id=BAMLH0A0HYM2&api_key=%s&file_type=json", baseURL, c.apiKey)
-	resp, err := http.Get(url)
+	// Security: Use custom client with timeout to prevent resource exhaustion (DoS) if the external API hangs
+	resp, err := c.client.Get(url)
 	if err != nil {
 		log.Printf("Error fetching data: %v", err)
 		return nil, err


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The FRED API client was using the default `http.Get` which has no timeout configured.
🎯 Impact: If the external API hangs, it could lead to resource exhaustion and potential Denial of Service (DoS) as goroutines wait indefinitely.
🔧 Fix: Changed `http.Get(url)` to use the pre-configured custom `c.client` which has an explicit timeout.
✅ Verification: Ran `go test ./internal/pkg/...` to verify correctness.

---
*PR created automatically by Jules for task [11527198046926135477](https://jules.google.com/task/11527198046926135477) started by @styner32*