### PR TITLE
🛡️ Sentinel: [HIGH] Fix Zip Bomb vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
+## 2026-03-24 - [Zip Bomb Vulnerability during Zip Extraction]
+**Vulnerability:** The application unzips files directly into memory using `io.Copy(outBuf, rc)` without bounding the total output size. An attacker could exploit this by providing a Zip bomb, causing Denial of Service (DoS) and Out Of Memory (OOM) errors.
+**Learning:** Using `io.Copy` to read from an untrusted archive straight into memory allows memory exhaustion. Limits must be placed dynamically based on already decompressed data.
+**Prevention:** To prevent Zip Bomb vulnerabilities, wrap the `io.Reader` using `io.LimitReader`, and maintain a running count of total bytes extracted across all files within an archive to enforce a strict overall limit.

--- a/internal/pkg/dart/dart.go
+++ b/internal/pkg/dart/dart.go
@@ -151,17 +151,27 @@ func (c *DartClient) GetDocument(rceptNo string) (string, error) {
 	}
 
 	outBuf := new(bytes.Buffer)
+	var totalRead int64
+	const maxDecompressedSize = 100 * 1024 * 1024 // 100MB limit to prevent zip bombs
+
 	for _, f := range zr.File {
 		rc, err := f.Open()
 		if err != nil {
 			return "", err
 		}
 
-		_, err = io.Copy(outBuf, rc)
+		lr := io.LimitReader(rc, maxDecompressedSize-totalRead+1)
+		n, err := io.Copy(outBuf, lr)
+		rc.Close()
+
 		if err != nil {
 			return "", err
 		}
-		rc.Close()
+
+		totalRead += n
+		if totalRead > maxDecompressedSize {
+			return "", fmt.Errorf("decompressed data exceeds limit")
+		}
 	}
 
 	return outBuf.String(), nil


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The application extracts ZIP files using `io.Copy` straight into a `bytes.Buffer` in memory without any size bounds, which allows for Zip Bomb attacks causing DoS/OOM.
🎯 Impact: A malicious ZIP payload could crash the application due to out-of-memory errors by exploiting large compression ratios.
🔧 Fix: Introduced an overall size limit (100MB) via `io.LimitReader` and tracked total extracted bytes across the archive.
✅ Verification: Ran `go build ./internal/pkg/...` and `go test ./internal/pkg/...` to verify compilation and that no regressions were introduced. Also removed scratchpad files.

---
*PR created automatically by Jules for task [14515725998778916001](https://jules.google.com/task/14515725998778916001) started by @styner32*