### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Zip Bomb Vulnerability in DART Client

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,7 +14,14 @@
 **Vulnerability:** The application used a query parameter to dynamically set database limits in `getLimitWithDefault()`, but did not validate that the limit was strictly positive and adequately bounded. GORM treats a negative limit (like `-1`) as "no limit", which an attacker could use to bypass pagination and fetch an excessively large dataset into memory, causing Denial of Service (DoS) or Out of Memory (OOM) errors.
 **Learning:** Object Relational Mappers (ORMs) like GORM have specific behaviors regarding default or special numeric arguments. In this case, passing negative values disables limits. It highlights the importance of not just capping the maximum value, but verifying lower bounds.
 **Prevention:** Always ensure pagination limit parameters are explicitly bounded to a strictly positive range (e.g., `0 < limit <= MAX_LIMIT`) before passing them to ORMs or database engines.
+
 ## 2026-06-29 - [Missing HTTP Timeout in API Clients]
+
 **Vulnerability:** External HTTP API requests (e.g., to FRED, Binance) used the default `http.Get` function without an explicit timeout configured.
 **Learning:** The default package-level `http.Get`, `http.Post`, etc., do not enforce any timeouts. If the external server hangs or responds very slowly, the connection will remain open indefinitely. In a concurrent environment, this can lead to thread/goroutine exhaustion, file descriptor limits being reached, and ultimately a Denial of Service (DoS) of the application.
 **Prevention:** Always use a custom instantiated `http.Client` with a strictly defined `Timeout` property (e.g., `&http.Client{Timeout: 10 * time.Second}`) when interacting with external networks. Avoid the default `http` package convenience functions.
+
+## 2024-05-24 - [Zip Bomb Vulnerability in DART Archive Extraction]
+**Vulnerability:** The application unzipped files directly into memory without bounding the aggregate size of decompressed data across the archive. This made it vulnerable to decompression bomb (Zip Bomb) attacks leading to memory exhaustion (OOM) or Denial of Service (DoS).
+**Learning:** Even when processing data from seemingly trusted third-party APIs like DART, we must assume the input data format could be malformed or exploited. Decompressing archives without tracking the cumulative bytes read is dangerous.
+**Prevention:** Always use `io.LimitReader` and track the total bytes decompressed against a strict limit (e.g., 100MB) when extracting archives, returning an error if the limit is exceeded.

--- a/internal/pkg/dart/dart.go
+++ b/internal/pkg/dart/dart.go
@@ -150,6 +150,12 @@ func (c *DartClient) GetDocument(rceptNo string) (string, error) {
 		return "", err
 	}
 
+	// SECURITY: Prevent Zip Bomb / memory exhaustion by limiting decompressed data to 100MB across all files
+	if len(zr.File) > 100 {
+		return "", fmt.Errorf("too many files in archive")
+	}
+
+	remainingBytes := int64(100 * 1024 * 1024)
 	outBuf := new(bytes.Buffer)
 	for _, f := range zr.File {
 		rc, err := f.Open()
@@ -157,11 +163,17 @@ func (c *DartClient) GetDocument(rceptNo string) (string, error) {
 			return "", err
 		}
 
-		_, err = io.Copy(outBuf, rc)
+		limitReader := io.LimitReader(rc, remainingBytes+1)
+		copied, err := io.Copy(outBuf, limitReader)
+		rc.Close()
+
+		if copied > remainingBytes {
+			return "", fmt.Errorf("decompressed data exceeds maximum allowed size")
+		}
 		if err != nil {
 			return "", err
 		}
-		rc.Close()
+		remainingBytes -= copied
 	}
 
 	return outBuf.String(), nil
@@ -235,6 +247,11 @@ func (c *DartClient) GetCompanies() ([]Company, error) {
 		return nil, err
 	}
 
+	// SECURITY: Prevent Zip Bomb / memory exhaustion by limiting decompressed data to 100MB across all files
+	if len(zr.File) > 100 {
+		return nil, fmt.Errorf("too many files in archive")
+	}
+	remainingBytes := int64(100 * 1024 * 1024)
 	outBuf := new(bytes.Buffer)
 	for _, f := range zr.File {
 		rc, err := f.Open()
@@ -242,12 +259,17 @@ func (c *DartClient) GetCompanies() ([]Company, error) {
 			return nil, err
 		}
 
-		_, err = io.Copy(outBuf, rc)
+		limitReader := io.LimitReader(rc, remainingBytes+1)
+		copied, err := io.Copy(outBuf, limitReader)
 		rc.Close()
 
+		if copied > remainingBytes {
+			return nil, fmt.Errorf("decompressed data exceeds maximum allowed size")
+		}
 		if err != nil {
 			return nil, err
 		}
+		remainingBytes -= copied
 	}
 
 	dec := xml.NewDecoder(bytes.NewReader(outBuf.Bytes()))


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Zip Bomb / Memory Exhaustion vulnerability when decompressing archives in the DART API client.
🎯 Impact: A malformed or maliciously crafted ZIP file could decompress to an excessively large size in memory, causing Out-Of-Memory (OOM) errors and bringing down the service.
🔧 Fix: Applied `io.LimitReader` when reading files from ZIP archives in both `GetDocument` and `GetCompanies` methods, tracking cumulative bytes across the archive, and bounding it to a strict 100MB limit.
✅ Verification: Verified fix correctness by running tests on the `internal/pkg/dart/...` package.

---
*PR created automatically by Jules for task [15571518167007859974](https://jules.google.com/task/15571518167007859974) started by @styner32*